### PR TITLE
Fix exit scene behavior (when exit is anticipated)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { window } from 'vscode';
-import { ManimShell } from './manimShell';
+import { ManimShell, NoActiveShellError } from './manimShell';
 import { ManimCell } from './manimCell';
 import { ManimCellRanges } from './manimCellRanges';
 import { previewCode } from './previewCode';
@@ -152,8 +152,13 @@ async function previewSelection() {
 async function clearScene() {
 	try {
 		await ManimShell.instance.executeCommandErrorOnNoActiveSession("clear()");
-	} catch (NoActiveSessionError) {
-		Window.showErrorMessage('No active Manim session found to remove objects from.');
+	} catch (error) {
+		if (error instanceof NoActiveShellError) {
+			Window.showErrorMessage('No active Manim session found to remove objects from.');
+		} else {
+			Logger.error(`💥 Error while trying to remove objects from scene: ${error}`);
+			throw error;
+		}
 	}
 }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -161,19 +161,19 @@ export class Logger {
  */
 export class Window {
 
-    public static showInformationMessage(message: string) {
+    public static async showInformationMessage(message: string) {
         Logger.info(`💡 ${message}`);
-        window.showInformationMessage(message);
+        await window.showInformationMessage(message);
     }
 
-    public static showWarningMessage(message: string, ...items: string[]) {
+    public static async showWarningMessage(message: string, ...items: string[]) {
         Logger.warn(`💡 ${message}`);
-        window.showWarningMessage(message, ...items);
+        await window.showWarningMessage(message, ...items);
     }
 
-    public static showErrorMessage(message: string) {
+    public static async showErrorMessage(message: string) {
         Logger.error(`💡 ${message}`);
-        window.showErrorMessage(message);
+        await window.showErrorMessage(message);
     }
 }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -163,17 +163,17 @@ export class Window {
 
     public static async showInformationMessage(message: string) {
         Logger.info(`💡 ${message}`);
-        await window.showInformationMessage(message);
+        return await window.showInformationMessage(message);
     }
 
     public static async showWarningMessage(message: string, ...items: string[]) {
         Logger.warn(`💡 ${message}`);
-        await window.showWarningMessage(message, ...items);
+        return await window.showWarningMessage(message, ...items);
     }
 
     public static async showErrorMessage(message: string) {
         Logger.error(`💡 ${message}`);
-        await window.showErrorMessage(message);
+        return await window.showErrorMessage(message);
     }
 }
 

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -383,7 +383,7 @@ export class ManimShell {
 
     /**
      * Ask the user if they want to kill the active scene. Might modify the
-     * setting that control if the user should be asked in the future.
+     * setting that controls if the user should be asked in the future.
      * 
      * @returns true if the user wants to kill the active scene, false otherwise.
      */
@@ -394,6 +394,9 @@ export class ManimShell {
         const selection = await Window.showWarningMessage(
             "We need to kill your Manim session to spawn a new one.",
             "Kill it", KILL_IT_ALWAYS_OPTION, CANCEL_OPTION);
+        if (selection === undefined) {
+            Logger.warn("❌ User selection undefined, but shouldn't be");
+        }
         if (selection === undefined || selection === CANCEL_OPTION) {
             return false;
         }

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -395,6 +395,10 @@ export class ManimShell {
         if (this.activeShell) {
             Logger.debug("🔚 Force-quitting active shell");
             this.activeShell.dispose();
+            // This is also taken care of when we detect that the shell has ended
+            // in the `onDidEndTerminalShellExecution` event handler. However,
+            // it doesn't harm to reset the active shell here as well just to
+            // be sure.
             this.resetActiveShell();
         } else {
             Logger.debug("🔚 No active shell found to force quit");

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -331,7 +331,9 @@ export class ManimShell {
                 const shouldAsk = await vscode.workspace.getConfiguration("manim-notebook")
                     .get("confirmKillingActiveSceneToStartNewOne");
                 if (shouldAsk) {
+                    Logger.debug("🔆 Active shell found, asking user to kill active scene");
                     if (!await this.doesUserWantToKillActiveScene()) {
+                        Logger.debug("🔆 User didn't want to kill active scene");
                         return;
                     }
                 }

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -314,6 +314,7 @@ export class ManimShell {
                     }
                 }
                 exitScene();
+                this.resetActiveShell();
             }
             this.activeShell = window.createTerminal();
         }
@@ -485,14 +486,19 @@ export class ManimShell {
                 for await (const data of withoutAnsiCodes(stream)) {
                     console.log(`🎯: ${data}`);
 
-                    this.eventEmitter.emit(ManimShellEvent.DATA, data);
-
                     if (data.match(MANIM_WELCOME_REGEX)) {
                         if (this.activeShell && this.activeShell !== event.terminal) {
                             exitScene(); // Manim detected in new terminal
+                            this.resetActiveShell();
                         }
                         this.activeShell = event.terminal;
                     }
+
+                    if (this.activeShell !== event.terminal) {
+                        return;
+                    }
+
+                    this.eventEmitter.emit(ManimShellEvent.DATA, data);
 
                     if (data.match(KEYBOARD_INTERRUPT_REGEX)) {
                         this.eventEmitter.emit(ManimShellEvent.KEYBOARD_INTERRUPT);

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -519,7 +519,7 @@ export class ManimShell {
                     // overlapping commands, e.g. when one shell is exited
                     // and another one started.
                     if (this.activeShell !== event.terminal) {
-                        return;
+                        continue;
                     }
 
                     this.eventEmitter.emit(ManimShellEvent.DATA, data);

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -501,8 +501,6 @@ export class ManimShell {
             async (event: vscode.TerminalShellExecutionStartEvent) => {
                 const stream = event.execution.read();
                 for await (const data of withoutAnsiCodes(stream)) {
-                    this.eventEmitter.emit(ManimShellEvent.DATA, data);
-
                     if (data.match(MANIM_WELCOME_REGEX)) {
                         // Manim detected in new terminal
                         if (this.activeShell && this.activeShell !== event.terminal) {

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -338,7 +338,7 @@ export class ManimShell {
                     }
                 }
                 Logger.debug("🔆 User confirmed to kill active scene");
-                this.forceQuitActiveShell();
+                await this.forceQuitActiveShell();
             }
             this.activeShell = window.createTerminal();
         } else {
@@ -391,9 +391,10 @@ export class ManimShell {
      * running command (inside IPython) as would be expected.
      * See https://github.com/3b1b/manim/discussions/2236
      */
-    public forceQuitActiveShell() {
+    public async forceQuitActiveShell() {
         if (this.activeShell) {
             Logger.debug("🔚 Force-quitting active shell");
+            await this.sendKeyboardInterrupt();
             this.activeShell.dispose();
             // This is also taken care of when we detect that the shell has ended
             // in the `onDidEndTerminalShellExecution` event handler. However,
@@ -540,6 +541,7 @@ export class ManimShell {
     private async sendKeyboardInterrupt() {
         Logger.debug("💨 Sending keyboard interrupt to terminal");
         await this.activeShell?.sendText('\x03'); // send `Ctrl+C`
+        await new Promise(resolve => setTimeout(resolve, 250));
     }
 
     /**
@@ -565,7 +567,7 @@ export class ManimShell {
                         // Manim detected in new terminal
                         if (this.activeShell && this.activeShell !== event.terminal) {
                             Logger.debug("👋 Manim detected in new terminal, exiting old scene");
-                            this.forceQuitActiveShell();
+                            await this.forceQuitActiveShell();
                         }
                         Logger.debug("👋 Manim welcome string detected");
                         this.activeShell = event.terminal;

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -394,8 +394,9 @@ export class ManimShell {
     public async forceQuitActiveShell() {
         if (this.activeShell) {
             Logger.debug("🔚 Force-quitting active shell");
+            let lastActiveShell = this.activeShell;
             await this.sendKeyboardInterrupt();
-            this.activeShell.dispose();
+            lastActiveShell?.dispose();
             // This is also taken care of when we detect that the shell has ended
             // in the `onDidEndTerminalShellExecution` event handler. However,
             // it doesn't harm to reset the active shell here as well just to

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -418,7 +418,10 @@ export class ManimShell {
      * Manim session (IPython environment), is considered inactive.
      */
     private hasActiveShell(): boolean {
-        return this.activeShell !== null && this.activeShell.exitStatus === undefined;
+        const hasActiveShell =
+            this.activeShell !== null && this.activeShell.exitStatus === undefined;
+        Logger.debug(`👩‍💻 Has active shell?: ${hasActiveShell}`);
+        return hasActiveShell;
     }
 
     /**

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -514,6 +514,10 @@ export class ManimShell {
                         this.activeShell = event.terminal;
                     }
 
+                    // Subsequent data handling should only occur for the
+                    // currently active shell. This is important during
+                    // overlapping commands, e.g. when one shell is exited
+                    // and another one started.
                     if (this.activeShell !== event.terminal) {
                         return;
                     }

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -99,8 +99,6 @@ export interface CommandExecutionEventHandler {
  */
 export class NoActiveShellError extends Error { }
 
-export class SceneKilled extends Error { }
-
 /**
  * Wrapper around the IPython terminal that ManimGL uses. Ensures that commands
  * are executed at the right place and spans a new Manim session if necessary.

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -58,13 +58,7 @@ enum ManimShellEvent {
      * execution has ended before we have detected the start of the ManimGL
      * session.
      */
-    MANIM_NOT_STARTED = 'manimglNotStarted',
-
-    /**
-     * Event only emitted when requested by the exit command. This is used to
-     * wait until the Manim session has exited.
-     */
-    EXIT = 'exit'
+    MANIM_NOT_STARTED = 'manimglNotStarted'
 }
 
 /**
@@ -150,8 +144,6 @@ export class ManimShell {
      */
     private detectShellExecutionEnd = true;
 
-    private shouldSignalExit = false;
-
     private constructor() {
         this.initiateTerminalDataReading();
 
@@ -198,17 +190,6 @@ export class ManimShell {
     ) {
         await this.execCommand(
             command, waitUntilFinished, forceExecute, true, undefined, undefined);
-    }
-
-    public async executeExitCommand(command: string) {
-        await this.execCommand(
-            command, false, true, true, undefined, undefined);
-
-        // wait until the Manim session has exited
-        this.shouldSignalExit = true;
-        await new Promise(resolve => this.eventEmitter.once(ManimShellEvent.EXIT, resolve));
-
-        this.resetActiveShell();
     }
 
     /**
@@ -332,7 +313,7 @@ export class ManimShell {
                         return;
                     }
                 }
-                await exitScene();
+                exitScene();
             }
             this.activeShell = window.createTerminal();
         }
@@ -365,7 +346,6 @@ export class ManimShell {
         this.iPythonCellCount = 0;
         this.activeShell = null;
         this.shellWeTryToSpawnIn = null;
-        this.shouldSignalExit = false;
         this.eventEmitter.removeAllListeners();
     }
 
@@ -541,12 +521,6 @@ export class ManimShell {
                         "Manim session could not be started."
                         + " Have you verified that `manimgl` is installed?");
                     event.terminal.show();
-                    return;
-                }
-
-                if (this.shouldSignalExit && event.terminal === this.activeShell) {
-                    this.eventEmitter.emit(ManimShellEvent.EXIT);
-                    this.shouldSignalExit = false;
                     return;
                 }
 

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -537,6 +537,7 @@ export class ManimShell {
                     if (data.match(MANIM_WELCOME_REGEX)) {
                         // Manim detected in new terminal
                         if (this.activeShell && this.activeShell !== event.terminal) {
+                            Logger.debug("👋 Manim detected in new terminal, exiting old scene");
                             await this.handleExit();
                         }
                         Logger.debug("👋 Manim welcome string detected");

--- a/src/previewCode.ts
+++ b/src/previewCode.ts
@@ -39,6 +39,9 @@ export async function previewCode(code: string, startLine: number): Promise<void
             },
             onData: (data) => {
                 progress?.reportOnData(data);
+            },
+            onReset: () => {
+                progress?.finish();
             }
         });
     } finally {

--- a/src/startStopScene.ts
+++ b/src/startStopScene.ts
@@ -109,7 +109,7 @@ export async function startScene(lineStart?: number) {
  */
 export async function exitScene() {
     try {
-        await ManimShell.instance.executeCommandErrorOnNoActiveSession("exit()", false, true);
+        await ManimShell.instance.executeExitCommand("exit()");
     } catch(NoActiveSessionError) {
         window.showErrorMessage('No active Manim session found to exit.');
     }

--- a/src/startStopScene.ts
+++ b/src/startStopScene.ts
@@ -109,7 +109,7 @@ export async function startScene(lineStart?: number) {
  */
 export async function exitScene() {
     try {
-        await ManimShell.instance.executeExitCommand("exit()");
+        await ManimShell.instance.executeCommandErrorOnNoActiveSession("exit()", false, true);
     } catch(NoActiveSessionError) {
         window.showErrorMessage('No active Manim session found to exit.');
     }

--- a/src/startStopScene.ts
+++ b/src/startStopScene.ts
@@ -105,18 +105,11 @@ export async function startScene(lineStart?: number) {
 }
 
 /**
- * Runs the `exit()` command in the terminal to close the animation window
- * and the IPython terminal.
+ * Force-quits the active Manim session by disposing the respective VSCode
+ * terminal that is currently hosting the session.
+ * 
+ * See `forceQuitActiveShell()` for more details.
  */
 export async function exitScene() {
-    try {
-        await ManimShell.instance.executeCommandErrorOnNoActiveSession("exit()", false, true);
-    } catch (error) {
-        if (error instanceof NoActiveShellError) {
-            Window.showErrorMessage('No active Manim session found to exit.');
-        } else {
-            Logger.error(`💥 Error while trying to exit scene: ${error}`);
-            throw error;
-        }
-    }
+    ManimShell.instance.forceQuitActiveShell();
 }

--- a/src/startStopScene.ts
+++ b/src/startStopScene.ts
@@ -111,5 +111,5 @@ export async function startScene(lineStart?: number) {
  * See `forceQuitActiveShell()` for more details.
  */
 export async function exitScene() {
-    ManimShell.instance.forceQuitActiveShell();
+    await ManimShell.instance.forceQuitActiveShell();
 }

--- a/src/startStopScene.ts
+++ b/src/startStopScene.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { ManimShell } from './manimShell';
+import { ManimShell, NoActiveShellError } from './manimShell';
 import { window } from 'vscode';
 import { Logger, Window } from './logger';
 
@@ -111,7 +111,12 @@ export async function startScene(lineStart?: number) {
 export async function exitScene() {
     try {
         await ManimShell.instance.executeCommandErrorOnNoActiveSession("exit()", false, true);
-    } catch (NoActiveSessionError) {
-        Window.showErrorMessage('No active Manim session found to exit.');
+    } catch (error) {
+        if (error instanceof NoActiveShellError) {
+            Window.showErrorMessage('No active Manim session found to exit.');
+        } else {
+            Logger.error(`💥 Error while trying to exit scene: ${error}`);
+            throw error;
+        }
     }
 }


### PR DESCRIPTION
In this PR, we fix the following situations:
1. Start Scene somewhere. Then start scene at another line. Confirm `Kill it`. Before this change, this resulted in a new scene being created and after that being immediately destroyed. The Manim Shell was left in a weird state.
2. Preview a Manim Cell. While previewing issue "Start scene" somewhere else and confirm `Kill it`. Before this change, the progress notification would remain frozen in the last position indefinitely.
3. Preview a Manim Cell. While previewing, manually open a new terminal, start `manimgl` in there. The first session should automatically exit, while the second is booting up.

### Known limitations
- We currently don't detect when the user forces the shell to exit by other means, e.g. by clicking on the trash bin. This may result in indefinite progress bars when force-quitting the shell during previewing. This can be tackled in a future PR.