### PR TITLE
Reset state upon manual terminal closing

### DIFF
--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -370,6 +370,9 @@ export class ManimShell {
     /**
     * Resets the active shell such that a new terminal is created on the next
     * command execution.
+    * 
+    * This will also remove all event listeners! Having called this method
+    * you should NOT emit any events anymore, as they will not be caught.
     */
     public resetActiveShell() {
         Logger.debug("💫 Reset active shell");
@@ -649,11 +652,10 @@ export class ManimShell {
                 return;
             }
             Logger.debug("🔚 Active shell closed");
-            await this.forceQuitActiveShell();
-            this.resetActiveShell();
-            Logger.debug("🔚 Emitting last clean-up events");
             this.eventEmitter.emit(ManimShellEvent.MANIM_NOT_STARTED);
             this.eventEmitter.emit(ManimShellEvent.KEYBOARD_INTERRUPT);
+            await this.forceQuitActiveShell();
+            this.resetActiveShell();
         });
     }
 }

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -81,7 +81,7 @@ export interface CommandExecutionEventHandler {
      * during Manim startup), the shell might not exist anymore after the
      * command was issued.
      */
-    onCommandIssued?: (shellStillExists: any) => void;
+    onCommandIssued?: (shellStillExists: boolean) => void;
 
     /**
      * Callback that is invoked when data is received from the active Manim

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -81,7 +81,7 @@ export interface CommandExecutionEventHandler {
      * during Manim startup), the shell might not exist anymore after the
      * command was issued.
      */
-    onCommandIssued?: (shellStillExists) => void;
+    onCommandIssued?: (shellStillExists: any) => void;
 
     /**
      * Callback that is invoked when data is received from the active Manim

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -633,10 +633,16 @@ export class ManimShell {
             });
 
         /**
-         * This even is fired when a terminal is closed manually by the user.
+         * This event is fired when a terminal is closed manually by the user.
          * In this case, we can only do our best to clean up since the terminal
          * is probably not able to receive commands anymore. It's mostly for us
-         * to reset all states that we're ready for the next command.
+         * to reset all states such that we're ready for the next command.
+         * 
+         * When closing while previewing a scene, the terminal is closed, however
+         * we are not able to send a keyboard interrupt anymore. Therefore,
+         * ManimGL will take a few seconds to actually close its window. When
+         * the user employs our "Quit preview" command instead, the preview will
+         * be closed immediately, so that one is preferred.
          */
         window.onDidCloseTerminal(async (terminal: Terminal) => {
             if (terminal !== this.activeShell) {

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -651,7 +651,7 @@ export class ManimShell {
          * we are not able to send a keyboard interrupt anymore. Therefore,
          * ManimGL will take a few seconds to actually close its window. When
          * the user employs our "Quit preview" command instead, the preview will
-         * be closed immediately, so that one is preferred.
+         * be closed immediately.
          */
         window.onDidCloseTerminal(async (terminal: Terminal) => {
             if (terminal !== this.activeShell) {

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -376,8 +376,9 @@ export class ManimShell {
     * Resets the active shell such that a new terminal is created on the next
     * command execution.
     * 
-    * This will also remove all event listeners! Having called this method
-    * you should NOT emit any events anymore, as they will not be caught.
+    * This will also remove all event listeners! Having called this method,
+    * you should NOT emit any events anymore before a new Manim shell is
+    * detected, as those events would not be caught by any listeners.
     */
     public resetActiveShell() {
         Logger.debug("💫 Reset active shell");

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -631,6 +631,24 @@ export class ManimShell {
                     this.resetActiveShell();
                 }
             });
+
+        /**
+         * This even is fired when a terminal is closed manually by the user.
+         * In this case, we can only do our best to clean up since the terminal
+         * is probably not able to receive commands anymore. It's mostly for us
+         * to reset all states that we're ready for the next command.
+         */
+        window.onDidCloseTerminal(async (terminal: Terminal) => {
+            if (terminal !== this.activeShell) {
+                return;
+            }
+            Logger.debug("🔚 Active shell closed");
+            await this.forceQuitActiveShell();
+            this.resetActiveShell();
+            Logger.debug("🔚 Emitting last clean-up events");
+            this.eventEmitter.emit(ManimShellEvent.MANIM_NOT_STARTED);
+            this.eventEmitter.emit(ManimShellEvent.KEYBOARD_INTERRUPT);
+        });
     }
 }
 

--- a/src/previewCode.ts
+++ b/src/previewCode.ts
@@ -34,10 +34,15 @@ export async function previewCode(code: string, startLine: number): Promise<void
 
         await ManimShell.instance.executeCommand(
             PREVIEW_COMMAND, startLine, true, {
-            onCommandIssued: () => {
+            onCommandIssued: (shellStillExists) => {
                 Logger.debug(`📊 Command issued: ${PREVIEW_COMMAND}. Will restore clipboard`);
                 restoreClipboard(clipboardBuffer);
-                progress = new PreviewProgress();
+                if (shellStillExists) {
+                    Logger.debug("📊 Initializing preview progress");
+                    progress = new PreviewProgress();
+                } else {
+                    Logger.debug("📊 Shell was closed in the meantime, not showing progress");
+                }
             },
             onData: (data) => {
                 progress?.reportOnData(data);


### PR DESCRIPTION
With this PR, we detect the event of a user _manually_ closing a terminal that hosts the _active_ Manim IPython session. Further behavior is described in the docstrings:

https://github.com/Manim-Notebook/manim-notebook/blob/8283ad074cbebb730d71a958dc835ae4016481ef/src/manimShell.ts#L644-L655

Some reset events might be fired multiple times in the end, but it's better to be safe than sorry here. Multiple calls to `resetActiveShell()` from different places of the code is not a problem.

**While testing this, please try to force-quit the terminal manually in many different situations to make sure that no state is left dangling, e.g. some notifications still showing or subsequent commands not working anymore.**