### PR TITLE
Show notification if no active Manim session when trying to quit

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -171,8 +171,7 @@ async function clearScene() {
 		await ManimShell.instance.executeCommandErrorOnNoActiveSession("clear()");
 	} catch (error) {
 		if (error instanceof NoActiveShellError) {
-			Window.showInformationMessage(
-				'No active Manim session found to remove objects from.');
+			Window.showWarningMessage('No active Manim session found to remove objects from.');
 			return;
 		}
 		Logger.error(`💥 Error while trying to remove objects from scene: ${error}`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -171,11 +171,12 @@ async function clearScene() {
 		await ManimShell.instance.executeCommandErrorOnNoActiveSession("clear()");
 	} catch (error) {
 		if (error instanceof NoActiveShellError) {
-			Window.showErrorMessage('No active Manim session found to remove objects from.');
-		} else {
-			Logger.error(`💥 Error while trying to remove objects from scene: ${error}`);
-			throw error;
+			Window.showInformationMessage(
+				'No active Manim session found to remove objects from.');
+			return;
 		}
+		Logger.error(`💥 Error while trying to remove objects from scene: ${error}`);
+		throw error;
 	}
 }
 

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -259,8 +259,8 @@ export class ManimShell {
             return;
         }
 
-        if (errorOnNoActiveShell && !this.hasActiveShell()) {
-            throw new NoActiveShellError();
+        if (errorOnNoActiveShell) {
+            this.errorOnNoActiveShell();
         }
 
         if (this.isExecutingCommand) {
@@ -309,6 +309,15 @@ export class ManimShell {
             Logger.debug(`🕒 Waiting until command has finished: ${command}`);
             await this.waitUntilCommandFinished(currentExecutionCount);
             Logger.debug(`🕒 Command has finished: ${command}`);
+        }
+    }
+
+    /**
+     * Errors if no active shell is found.
+     */
+    public errorOnNoActiveShell() {
+        if (!this.hasActiveShell()) {
+            throw new NoActiveShellError();
         }
     }
 

--- a/src/startStopScene.ts
+++ b/src/startStopScene.ts
@@ -116,7 +116,7 @@ export async function exitScene() {
         await ManimShell.instance.forceQuitActiveShell();
     } catch (error) {
         if (error instanceof NoActiveShellError) {
-            Window.showInformationMessage("No active Manim session found to quit.");
+            Window.showWarningMessage("No active Manim session found to quit.");
             return;
         }
         Logger.error(`💥 Error while trying to exit the scene: ${error}`);

--- a/src/startStopScene.ts
+++ b/src/startStopScene.ts
@@ -111,5 +111,15 @@ export async function startScene(lineStart?: number) {
  * See `forceQuitActiveShell()` for more details.
  */
 export async function exitScene() {
-    await ManimShell.instance.forceQuitActiveShell();
+    try {
+        ManimShell.instance.errorOnNoActiveShell();
+        await ManimShell.instance.forceQuitActiveShell();
+    } catch (error) {
+        if (error instanceof NoActiveShellError) {
+            Window.showInformationMessage("No active Manim session found to quit.");
+            return;
+        }
+        Logger.error(`💥 Error while trying to exit the scene: ${error}`);
+        throw error;
+    }
 }


### PR DESCRIPTION
Fixes #71, i.e. **we now show an information message whenever the user tries to quit the scene while no active scene is running.**

I've already implemented such a notification beforehand but accidentally removed it in #48 when fixing the exit scene behavior where the `exitScene()` was rewritten.


### Off-topic

The error message notification when clearing the scene while no active session exists, is changed to an _information_ message. An _information_ message is also used for the notification upon quitting (when no active session exists).