### PR TITLE
Specify more VSCode workspace settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
 	// for the documentation about the extensions.json format
 	"recommendations": [
 		"dbaeumer.vscode-eslint",
-		"ms-vscode.extension-test-runner"
+		"ms-vscode.extension-test-runner",
+		"streetsidesoftware.code-spell-checker"
 	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,59 @@
-// Place your settings in this file to overwrite default and user settings.
 {
-	"files.exclude": {
-		"out": false // set this to true to hide the "out" folder with the compiled JS files
-	},
-	"search.exclude": {
-		"out": true // set this to false to include "out" folder in search results
-	},
-	// Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-	"typescript.tsc.autoDetect": "off"
+    //////////////////////////////////////
+    // TypeScript
+    //////////////////////////////////////
+    // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
+    "typescript.tsc.autoDetect": "off",
+    //////////////////////////////////////
+    // Files & Folders
+    //////////////////////////////////////
+    "files.exclude": {
+        "out": false // set this to true to hide the "out" folder with the compiled JS files
+    },
+    "search.exclude": {
+        "out": true // set this to false to include "out" folder in search results
+    },
+    //////////////////////////////////////
+    // Editor
+    //////////////////////////////////////
+    "editor.tabSize": 4,
+    "editor.insertSpaces": true,
+    "editor.detectIndentation": false,
+    "editor.wordWrap": "wordWrapColumn",
+    "editor.wordWrapColumn": 100, // toggle via Alt + Z shortcut
+    "editor.mouseWheelZoom": true,
+    "editor.rulers": [
+        {
+            "column": 80, // soft limit
+            "color": "#e5e5e5"
+        },
+        {
+            "column": 100, // hard limit
+            "color": "#c9c9c9"
+        }
+    ],
+    //////////////////////////////////////
+    // Git
+    //////////////////////////////////////
+    "git.inputValidation": true,
+    "git.inputValidationSubjectLength": 50,
+    "git.inputValidationLength": 72,
+    //////////////////////////////////////
+    // Spell Checker
+    //////////////////////////////////////
+    "cSpell.words": [
+        "ansi",
+        "Ansi",
+        "autoplay",
+        "github",
+        "ipython",
+        "Keybord",
+        "Logfile",
+        "manim",
+        "Manim",
+        "MANIM",
+        "manimgl",
+        "Sanderson's",
+        "youtube"
+    ]
 }


### PR DESCRIPTION
- Here we add my favorite [**spell checker extension**](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) for VSCode to the recommended workspace extensions and populate the `settings.json` with some words that the spell checker should ignore. In the future, just use the quick fix `Add <word> to workspace settings` if the spell checker is not aware of a word. Then don't forget to include the `settings.json` in your commits.
- I've also added some settings that have proven to be a nice default for other projects. These settings relate to **Git** as well as the **editor** itself (showing some rulers). Of course settings like the ruler color are very debatable, this is just a default value that you can for sure overwrite locally if you'd like to. I like to aim for 80 colons and only if necessary surpass it. The editor will wrap every line that is longer than 100 colons (toggle via `Alt + Z`) just as a visual reminder that this line is probably too long.