### PR TITLE
Add quotes around file path for paths with spaces

### DIFF
--- a/src/startStopScene.ts
+++ b/src/startStopScene.ts
@@ -71,7 +71,7 @@ export async function startScene(lineStart?: number) {
 
     // Create the command
     const filePath = editor.document.fileName;  // absolute path
-    const cmds = ["manimgl", filePath, sceneName];
+    const cmds = ["manimgl", `\"${filePath}\"`, sceneName];
     let enter = false;
     if (cursorLine !== matchingClass.index) {
         cmds.push(`-se ${lineNumber + 1}`);

--- a/src/startStopScene.ts
+++ b/src/startStopScene.ts
@@ -71,7 +71,7 @@ export async function startScene(lineStart?: number) {
 
     // Create the command
     const filePath = editor.document.fileName;  // absolute path
-    const cmds = ["manimgl", `\"${filePath}\"`, sceneName];
+    const cmds = ["manimgl", `"${filePath}"`, sceneName];
     let enter = false;
     if (cursorLine !== matchingClass.index) {
         cmds.push(`-se ${lineNumber + 1}`);


### PR DESCRIPTION
In the current implementation `manimgl` will fail when we want to open a scene that is defined in a file containing whitespaces. To ensure the correct handling in this case, we enclose the respective variable in double quotes `"` when passed to `manimgl`.