### PR TITLE
Add option to delay commands after terminal start

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,9 +91,14 @@
           "markdownDescription": "Configures the number of milliseconds (ms) to wait before your clipboard is restored. (Your clipboard is used to temporarily copy the selected code to be accessible by Manim)."
         },
         "manim-notebook.confirmKillingActiveSceneToStartNewOne": {
-        "type": "boolean",
+          "type": "boolean",
           "default": true,
           "markdownDescription": "If enabled, you will be prompted to confirm killing an old session when you want to start a new scene at the cursor while an active scene is running."
+        },
+        "manim-notebook.delayNewTerminal": {
+          "type": "number",
+          "default": 0,
+          "markdownDescription": "Number of milliseconds (ms) to wait before executing any command in a newly opened terminal. This is useful when you have custom terminal startup commands that need to be executed before running Manim, e.g. a virtual environment activation (venv)."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
         "manim-notebook.delayNewTerminal": {
           "type": "number",
           "default": 0,
-          "markdownDescription": "Number of milliseconds (ms) to wait before executing any command in a newly opened terminal. This is useful when you have custom terminal startup commands that need to be executed before running Manim, e.g. a virtual environment activation (venv)."
+          "markdownDescription": "Number of milliseconds (ms) to wait before executing any command in a newly opened terminal. This is useful when you have custom terminal startup commands that need to be executed before running Manim, e.g. a virtual environment activation (Python venv)."
         }
       }
     }

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -540,7 +540,7 @@ export class ManimShell {
         if (delay > 600) {
             await window.withProgress({
                 location: vscode.ProgressLocation.Notification,
-                title: "Waiting user-defined delay for new terminal...",
+                title: "Waiting a user-defined delay for the new terminal...",
                 cancellable: false
             }, async (progress, token) => {
                 progress.report({ increment: 0 });

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -354,7 +354,7 @@ export class ManimShell {
                 Logger.debug("🔆 User confirmed to kill active scene");
                 await this.forceQuitActiveShell();
             }
-            this.activeShell = window.createTerminal();
+            await this.openNewTerminal();
         } else {
             Logger.debug("🔆 Executing start command that is requested for another command");
         }
@@ -512,13 +512,21 @@ export class ManimShell {
     private async retrieveOrInitActiveShell(startLine: number): Promise<Terminal> {
         if (!this.hasActiveShell()) {
             Logger.debug("🔍 No active shell found, requesting startScene");
-            this.activeShell = window.createTerminal();
+            await this.openNewTerminal();
             await startScene(startLine);
             Logger.debug("🔍 Started new scene to retrieve new shell");
         } else {
             Logger.debug("🔍 Active shell already there");
         }
         return this.activeShell as Terminal;
+    }
+
+    private async openNewTerminal() {
+        this.detectShellExecutionEnd = false;
+        this.activeShell = window.createTerminal();
+        // TODO: make time-out user-configurable
+        await new Promise(resolve => setTimeout(resolve, 2500));
+        this.detectShellExecutionEnd = true;
     }
 
     /**

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -521,10 +521,19 @@ export class ManimShell {
         return this.activeShell as Terminal;
     }
 
+    /**
+     * Opens a new terminal and sets it as the active shell. Afterwards, waits
+     * for a user-defined delay before allowing the terminal to be used, which
+     * might be useful for some activation scripts to load like virtualenvs etc.
+     */
     private async openNewTerminal() {
-        this.detectShellExecutionEnd = false;
         const delay: number = await vscode.workspace
             .getConfiguration("manim-notebook").get("delayNewTerminal")!;
+
+        // We don't want to detect shell execution ends here, since commands like
+        // `source venv/bin/activate` might on their own trigger a terminal
+        // execution end.
+        this.detectShellExecutionEnd = false;
 
         this.activeShell = window.createTerminal();
 


### PR DESCRIPTION
In some environments in might be necessary to wait a user-defined delay/timeout before executing any command in a newly created terminal. For example, when using the virtual Python environment `venv` which first has to source some activation script. 

**Therefore, we introduce a new delay setting to wait after a new terminal start. This setting defaults to `0` milliseconds, but can be adjusted as the user sees fit.**

Please make sure:
- that the extension works as usual when you didn't change anything.
- that you can increase the number of milliseconds and that this is actually respected as waiting time. For delays over `600` ms, a notification will also be shown indicating that we're waiting.