### PR TITLE
Better error message when `manimgl` fails

### DIFF
--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -634,7 +634,7 @@ export class ManimShell {
                     this.resetActiveShell();
                     Window.showErrorMessage(
                         "Manim session could not be started."
-                        + " Have you verified that `manimgl` is installed?");
+                        + " There was a problem running the `manimgl` command.");
                     event.terminal.show();
                     return;
                 }


### PR DESCRIPTION
When starting manimgl with our shortcut,
the 
> Have you verified that `manimgl` is installed?

error msg
doesn't capture all the reasons this command may fail.

I made a version which is more accurate.