### PR TITLE
Redesign Manim cells (and make more prominent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ VSCode extension for replicating Grant Sanderson's `manim` workflow for Sublime 
 
 **Note** this extension is specifically for [3b1b's original manim library](https://github.com/3b1b/manim), NOT the community version.
 
+
 ## Example usage
 
 1. [Install manimgl](https://3b1b.github.io/manim/getting_started/installation.html), make sure that the command `manimgl` works in your terminal
@@ -12,8 +13,6 @@ VSCode extension for replicating Grant Sanderson's `manim` workflow for Sublime 
 4. Run the VSCode command: `cmd+shift+p` -> `Manim Notebook: Start scene at cursor`  
     (This command runs `manimgl scene.py NAME_OF_SCENE -se <lineNumber>` in your terminal)  
     In the upper-right of your screen - the manim interactive video will appear.
-
-<br />
 
 Then you can do either:
 
@@ -26,8 +25,6 @@ Then you can do either:
     `cmd+shift+p` -> `Manim Notebook: Preview selected Manim code`  
     This will run the selected lines.
 
-
-<br /><br />
 
 ## Keybord shortcuts
 
@@ -50,9 +47,6 @@ All current commands are:
     Shortcut: `cmd+' cmd+w`
 
 
-
-<br /><br />
-
 ## Demonstration
 
 The resulting workflow can look like Grant's 🥳
@@ -62,17 +56,43 @@ The resulting workflow can look like Grant's 🥳
 <iframe width="560" height="315" src="https://www.youtube.com/embed/VaNHlFh0r5E?si=ClVdBSI1k_-mzKFr" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 
-<br /><br />
+## Customization
+
+- There are some settings that you can tweak, just press `Ctrl/Cmd + ,` in order to open the settings and search for `Manim Notebook`.
+- Customize the color of the Manim Cells in your `settings.json` file as [described here in the VSCode docs](https://code.visualstudio.com/docs/getstarted/themes#_customize-a-color-theme). Why not go for a more red-ish color of Manim Cells? 🎨
+
+
+```json
+// https://stackoverflow.com/a/71962342/
+// https://stackoverflow.com/a/77515370/
+// Use `[*Light*]` to match themes whose name contains `Light` in them.
+"workbench.colorCustomizations": {
+    "[*Light*]": {
+        "manimNotebookColors.baseColor": "#FF708A",
+        "manimNotebookColors.unfocused": "#FFBFCC"
+    },
+    "[*Dark*]": {
+        "manimNotebookColors.baseColor": "#FF708A",
+        "manimNotebookColors.unfocused": "#804953"
+    },
+    "[*Light High Contrast*]": {
+        "manimNotebookColors.baseColor": "#FF5473",
+        "manimNotebookColors.unfocused": "#FFA3B6"
+    },
+    "[*Dark High Contrast*]": {
+        "manimNotebookColors.baseColor": "#FF5473",
+        "manimNotebookColors.unfocused": "#8C5660"
+    }
+}
+```
+
 
 ## Links
 
 - [GitHub](https://github.com/bhoov/manim-notebook)
-
 - [contributing](https://github.com/bhoov/manim-notebook/blob/main/CONTRIBUTING.md)
-
 - [wiki](https://github.com/bhoov/manim-notebook/wiki)
 
-<br /><br />
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ The resulting workflow can look like Grant's 🥳
 
 ## Customization
 
-- There are some settings that you can tweak, just press `Ctrl/Cmd + ,` in order to open the settings and search for `Manim Notebook`.
-- Customize the color of the Manim Cells in your `settings.json` file as [described here in the VSCode docs](https://code.visualstudio.com/docs/getstarted/themes#_customize-a-color-theme). Why not go for a more red-ish color of Manim Cells? 🎨
+- There are some extension settings that you can tweak: just press `Ctrl/Cmd + ,` in order to open the settings and search for `Manim Notebook`.
+- Customize the **color of the Manim Cells** in your `settings.json` file as [described here in the VSCode docs](https://code.visualstudio.com/docs/getstarted/themes#_customize-a-color-theme). Why not go for a more red-ish color? 🎨
 
 
 ```json
@@ -85,6 +85,36 @@ The resulting workflow can look like Grant's 🥳
     }
 }
 ```
+
+<details>
+
+<summary>See default blue-ish colors</summary>
+
+```json
+// https://stackoverflow.com/a/71962342/
+// https://stackoverflow.com/a/77515370/
+// Use `[*Light*]` to match themes whose name contains `Light` in them.
+"workbench.colorCustomizations": {
+    "[*Light*]": {
+        "manimNotebookColors.baseColor": "#2B7BD6",
+        "manimNotebookColors.unfocused": "#DCE9F7"
+    },
+    "[*Dark*]": {
+        "manimNotebookColors.baseColor": "#64A4ED",
+        "manimNotebookColors.unfocused": "#39506B"
+    },
+    "[*Light High Contrast*]": {
+        "manimNotebookColors.baseColor": "#216CC2",
+        "manimNotebookColors.unfocused": "#C3DDF7"
+    },
+    "[*Dark High Contrast*]": {
+        "manimNotebookColors.baseColor": "#75B6FF",
+        "manimNotebookColors.unfocused": "#3C5878"
+    }
+}
+```
+
+</details>
 
 
 ## Links

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "colors": [
       {
         "id": "manimNotebookColors.baseColor",
-        "description": "Base color used for the cell border and the start comment.",
+        "description": "Base color used for the Manim cell border and the start comment.",
         "defaults": {
             "dark": "#FF708A",
             "light": "#FF708A",
@@ -115,7 +115,7 @@
       },
       {
         "id": "manimNotebookColors.unfocused",
-        "description": "Color used for the cell border when the cell is not focused.",
+        "description": "Color used for the Manim cell border when the cell is not focused.",
         "defaults": {
           "dark": "#804953",
           "light": "#FFBFCC",

--- a/package.json
+++ b/package.json
@@ -107,11 +107,11 @@
         "id": "manimNotebookColors.baseColor",
         "description": "Base color used for the Manim cell border and the start comment.",
         "defaults": {
-            "dark": "#FF708A",
-            "light": "#FF708A",
-            "highContrast": "#FF5473",
-            "highContrastLight": "#FF5473"
-        }  
+          "dark": "#FF708A",
+          "light": "#FF708A",
+          "highContrast": "#FF5473",
+          "highContrastLight": "#FF5473"
+        }
       },
       {
         "id": "manimNotebookColors.unfocused",

--- a/package.json
+++ b/package.json
@@ -105,22 +105,22 @@
     "colors": [
       {
         "id": "manimNotebookColors.baseColor",
-        "description": "Base color used for the Manim cell border and the start comment.",
+        "description": "Base color used for the Manim cell border and the start comment that beings with `##`.",
         "defaults": {
-          "dark": "#FF708A",
-          "light": "#FF708A",
-          "highContrast": "#FF5473",
-          "highContrastLight": "#FF5473"
+          "dark": "#64A4ED",
+          "light": "#2B7BD6",
+          "highContrast": "#75B6FF",
+          "highContrastLight": "#216CC2"
         }
       },
       {
         "id": "manimNotebookColors.unfocused",
         "description": "Color used for the Manim cell border when the cell is not focused.",
         "defaults": {
-          "dark": "#804953",
-          "light": "#FFBFCC",
-          "highContrast": "#8C5660",
-          "highContrastLight": "#FFA3B6"
+          "dark": "#39506B",
+          "light": "#DCE9F7",
+          "highContrast": "#3C5878",
+          "highContrastLight": "#C3DDF7"
         }
       }
     ]

--- a/package.json
+++ b/package.json
@@ -99,6 +99,11 @@
           "type": "number",
           "default": 0,
           "markdownDescription": "Number of milliseconds (ms) to wait before executing any command in a newly opened terminal. This is useful when you have custom terminal startup commands that need to be executed before running Manim, e.g. a virtual environment activation (Python venv)."
+        },
+        "manim-notebook.showCellBorders": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "If enabled, Manim cells will have a border around them (top and bottom)."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -104,13 +104,18 @@
           "type": "boolean",
           "default": true,
           "markdownDescription": "If enabled, Manim cells will have a border around them (top and bottom)."
+        },
+        "manim-notebook.typesetStartCommentInBold": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "If enabled, the start comment of each cell (comment that begins with `##`) will be typeset in bold."
         }
       }
     },
     "colors": [
       {
         "id": "manimNotebookColors.baseColor",
-        "description": "Base color used for the Manim cell border and the start comment that beings with `##`.",
+        "description": "Base color used for the Manim cell border and the respective start comment (comment that begins with `##`).",
         "defaults": {
           "dark": "#64A4ED",
           "light": "#2B7BD6",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,29 @@
           "markdownDescription": "Number of milliseconds (ms) to wait before executing any command in a newly opened terminal. This is useful when you have custom terminal startup commands that need to be executed before running Manim, e.g. a virtual environment activation (Python venv)."
         }
       }
-    }
+    },
+    "colors": [
+      {
+        "id": "manimNotebookColors.baseColor",
+        "description": "Base color used for the cell border and the start comment.",
+        "defaults": {
+            "dark": "#FF708A",
+            "light": "#FF708A",
+            "highContrast": "#FF5473",
+            "highContrastLight": "#FF5473"
+        }  
+      },
+      {
+        "id": "manimNotebookColors.unfocused",
+        "description": "Color used for the cell border when the cell is not focused.",
+        "defaults": {
+          "dark": "#804953",
+          "light": "#FFBFCC",
+          "highContrast": "#8A4551",
+          "highContrastLight": "#FFA3B6"
+        }
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
         "defaults": {
           "dark": "#804953",
           "light": "#FFBFCC",
-          "highContrast": "#8A4551",
+          "highContrast": "#8C5660",
           "highContrastLight": "#FFA3B6"
         }
       }

--- a/src/manimCell.ts
+++ b/src/manimCell.ts
@@ -3,12 +3,18 @@ import { window } from 'vscode';
 import { ManimCellRanges } from './manimCellRanges';
 
 export class ManimCell implements vscode.CodeLensProvider, vscode.FoldingRangeProvider {
+    private cellStartCommentDecoration: vscode.TextEditorDecorationType;
     private cellTopDecoration: vscode.TextEditorDecorationType;
     private cellBottomDecoration: vscode.TextEditorDecorationType;
     private cellTopDecorationUnfocused: vscode.TextEditorDecorationType;
     private cellBottomDecorationUnfocused: vscode.TextEditorDecorationType;
 
     constructor() {
+        this.cellStartCommentDecoration = window.createTextEditorDecorationType({
+            isWholeLine: true,
+            fontWeight: 'bold',
+            color: new vscode.ThemeColor('manimNotebookColors.baseColor')
+        });
         this.cellTopDecoration = ManimCell.getBorder(true, true);
         this.cellBottomDecoration = ManimCell.getBorder(true, false);
         this.cellTopDecorationUnfocused = ManimCell.getBorder(false, true);
@@ -16,8 +22,10 @@ export class ManimCell implements vscode.CodeLensProvider, vscode.FoldingRangePr
     }
 
     private static getBorder(isFocused = true, isTop = true): vscode.TextEditorDecorationType {
-        const borderColor = isFocused ? 'interactive.activeCodeBorder' : 'interactive.inactiveCodeBorder';
-        const borderWidth = isTop ? '1.5px 0px 0px 0px' : '0px 0px 1.5px 0px';
+        const borderColor = isFocused
+            ? 'manimNotebookColors.baseColor'
+            : 'manimNotebookColors.unfocused';
+        const borderWidth = isTop ? '2px 0px 0px 0px' : '0px 0px 1.6px 0px';
         return window.createTextEditorDecorationType({
             borderColor: new vscode.ThemeColor(borderColor),
             borderWidth: borderWidth,
@@ -85,6 +93,8 @@ export class ManimCell implements vscode.CodeLensProvider, vscode.FoldingRangePr
             }
         });
 
+        editor.setDecorations(this.cellStartCommentDecoration,
+            topRangesFocused.concat(topRangesUnfocused));
         editor.setDecorations(this.cellTopDecoration, topRangesFocused);
         editor.setDecorations(this.cellBottomDecoration, bottomRangesFocused);
         editor.setDecorations(this.cellTopDecorationUnfocused, topRangesUnfocused);

--- a/src/manimCell.ts
+++ b/src/manimCell.ts
@@ -95,10 +95,20 @@ export class ManimCell implements vscode.CodeLensProvider, vscode.FoldingRangePr
 
         editor.setDecorations(this.cellStartCommentDecoration,
             topRangesFocused.concat(topRangesUnfocused));
-        editor.setDecorations(this.cellTopDecoration, topRangesFocused);
-        editor.setDecorations(this.cellBottomDecoration, bottomRangesFocused);
-        editor.setDecorations(this.cellTopDecorationUnfocused, topRangesUnfocused);
-        editor.setDecorations(this.cellBottomDecorationUnfocused, bottomRangesUnfocused);
+
+        const showBorders: number = vscode.workspace
+            .getConfiguration("manim-notebook").get("showCellBorders")!;
+        if (showBorders) {
+            editor.setDecorations(this.cellTopDecoration, topRangesFocused);
+            editor.setDecorations(this.cellBottomDecoration, bottomRangesFocused);
+            editor.setDecorations(this.cellTopDecorationUnfocused, topRangesUnfocused);
+            editor.setDecorations(this.cellBottomDecorationUnfocused, bottomRangesUnfocused);
+        } else {
+            editor.setDecorations(this.cellTopDecoration, []);
+            editor.setDecorations(this.cellBottomDecoration, []);
+            editor.setDecorations(this.cellTopDecorationUnfocused, []);
+            editor.setDecorations(this.cellBottomDecorationUnfocused, []);
+        }
     }
 
 }

--- a/src/manimCell.ts
+++ b/src/manimCell.ts
@@ -93,12 +93,18 @@ export class ManimCell implements vscode.CodeLensProvider, vscode.FoldingRangePr
             }
         });
 
-        editor.setDecorations(this.cellStartCommentDecoration,
-            topRangesFocused.concat(topRangesUnfocused));
+        const config = vscode.workspace.getConfiguration("manim-notebook");
 
-        const showBorders: number = vscode.workspace
-            .getConfiguration("manim-notebook").get("showCellBorders")!;
-        if (showBorders) {
+        // Start comment in bold
+        if (config.get("typesetStartCommentInBold")) {
+            editor.setDecorations(this.cellStartCommentDecoration,
+                topRangesFocused.concat(topRangesUnfocused));
+        } else {
+            editor.setDecorations(this.cellStartCommentDecoration, []);
+        }
+
+        // Cell borders
+        if (config.get("showCellBorders")) {
             editor.setDecorations(this.cellTopDecoration, topRangesFocused);
             editor.setDecorations(this.cellBottomDecoration, bottomRangesFocused);
             editor.setDecorations(this.cellTopDecorationUnfocused, topRangesUnfocused);


### PR DESCRIPTION
When working with our extension, I sometimes had a hard time identifying where cells end and start. Therefore,
- increase focused cell border width
- increase starting cell comments weight (they are not printed in bold)
- go with some (admittedly bold) new color scheme I came up with

Here's what the new redesign looks like for different themes. Please check the following themes locally:
- dark & dark (high contrast)
- light & light (high contrast)

**Edit: The default color choice is now a blue-tone, not a red-tone anymore as shown in these images.**

![New Manim Cell Look](https://github.com/user-attachments/assets/ce87d3e6-b631-4632-b072-e56acd906a26)

The kind of blueish red-tone I've chosen sets us apart in the sea of different colors in the editor. But of course color choice is very subjective, that's why users can choose any color they want in their `workbench.colorCustomizations` section. The ids for the colors we contribute will we visible in the extension overview page when installing it as written [here](https://code.visualstudio.com/api/references/theme-color#extension-colors). E.g. try out (only in light themes):

```json
"workbench.colorCustomizations": {
    "manimNotebookColors.baseColor": "#005EC7",
    "manimNotebookColors.unfocused": "#B1D3FA"
}
```