### PR TITLE
Fix preview command sometimes not executing on Windows

### DIFF
--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -18,6 +18,11 @@ const ANSI_CONTROL_SEQUENCE_REGEX = /(?:\x1B[@-Z\\-_]|[\x80-\x9A\x9C-\x9F]|(?:\x
 const IPYTHON_CELL_START_REGEX = /^\s*In \[\d+\]:/gm;
 
 /**
+ * Regular expression to match IPython multiline input "...:"
+ */
+const IPYTHON_MULTILINE_START_REGEX = /^\s*\.{3}:\s$/m;
+
+/**
  * Regular expression to match a KeyboardInterrupt.
  */
 const KEYBOARD_INTERRUPT_REGEX = /^\s*KeyboardInterrupt/m;
@@ -655,6 +660,14 @@ export class ManimShell {
                         this.iPythonCellCount = maxCellNumber;
                         Logger.debug(`📦 IPython cell ${maxCellNumber} detected`);
                         this.eventEmitter.emit(ManimShellEvent.IPYTHON_CELL_FINISHED);
+                    }
+
+                    if (this.isExecutingCommand && data.match(IPYTHON_MULTILINE_START_REGEX)) {
+                        Logger.debug(`💨 IPython multiline detected, sending extra newline`);
+                        // use sendText instead of ManimShell.exec as
+                        // shell integration does not work here
+                        // \x7F deletes the extra line ("...:") from IPython
+                        this.activeShell.sendText("\x7F");
                     }
 
                     if (data.match(ERROR_REGEX)) {

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -20,7 +20,7 @@ const IPYTHON_CELL_START_REGEX = /^\s*In \[\d+\]:/gm;
 /**
  * Regular expression to match IPython multiline input "...:"
  */
-const IPYTHON_MULTILINE_START_REGEX = /^\s*\.{3}:\s$/m;
+const IPYTHON_MULTILINE_START_REGEX = /^\s*\.{3}:\s+$/m;
 
 /**
  * Regular expression to match a KeyboardInterrupt.
@@ -488,12 +488,13 @@ export class ManimShell {
      * 
      * @param shell The shell to execute the command in.
      * @param command The command to execute in the shell.
+     * @param useShellIntegration Whether to use shell integration if available
      */
-    private exec(shell: Terminal, command: string) {
+    private exec(shell: Terminal, command: string, useShellIntegration = true) {
         this.detectShellExecutionEnd = false;
         Logger.debug("🔒 Shell execution end detection disabled");
 
-        if (shell.shellIntegration) {
+        if (useShellIntegration && shell.shellIntegration) {
             Logger.debug(`💨 Sending command to terminal (with shell integration): ${command}`);
             shell.shellIntegration.executeCommand(command);
         } else {
@@ -667,7 +668,7 @@ export class ManimShell {
                         // use sendText instead of ManimShell.exec as
                         // shell integration does not work here
                         // \x7F deletes the extra line ("...:") from IPython
-                        this.activeShell.sendText("\x7F");
+                        this.exec(this.activeShell, "\x7F", false);
                     }
 
                     if (data.match(ERROR_REGEX)) {

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -488,13 +488,12 @@ export class ManimShell {
      * 
      * @param shell The shell to execute the command in.
      * @param command The command to execute in the shell.
-     * @param useShellIntegration Whether to use shell integration if available
      */
-    private exec(shell: Terminal, command: string, useShellIntegration = true) {
+    private exec(shell: Terminal, command: string) {
         this.detectShellExecutionEnd = false;
         Logger.debug("🔒 Shell execution end detection disabled");
 
-        if (useShellIntegration && shell.shellIntegration) {
+        if (shell.shellIntegration) {
             Logger.debug(`💨 Sending command to terminal (with shell integration): ${command}`);
             shell.shellIntegration.executeCommand(command);
         } else {
@@ -665,10 +664,8 @@ export class ManimShell {
 
                     if (this.isExecutingCommand && data.match(IPYTHON_MULTILINE_START_REGEX)) {
                         Logger.debug(`💨 IPython multiline detected, sending extra newline`);
-                        // use sendText instead of ManimShell.exec as
-                        // shell integration does not work here
                         // \x7F deletes the extra line ("...:") from IPython
-                        this.exec(this.activeShell, "\x7F", false);
+                        this.exec(this.activeShell, "\x7F");
                     }
 
                     if (data.match(ERROR_REGEX)) {

--- a/src/previewCode.ts
+++ b/src/previewCode.ts
@@ -4,9 +4,8 @@ import { ManimShell } from './manimShell';
 import { EventEmitter } from 'events';
 import { Logger } from './logger';
 
-const PREVIEW_COMMAND = `\x0C checkpoint_paste()\x1b`;
+const PREVIEW_COMMAND = `\x0Ccheckpoint_paste()`;
 // \x0C: is Ctrl + L
-// \x1b: https://github.com/bhoov/manim-notebook/issues/18#issuecomment-2431146809
 
 /**
  * Interactively previews the given Manim code by means of the

--- a/src/previewCode.ts
+++ b/src/previewCode.ts
@@ -4,8 +4,8 @@ import { ManimShell } from './manimShell';
 import { EventEmitter } from 'events';
 import { Logger } from './logger';
 
+// \x0C: is Ctrl + L, which clears the terminal screen
 const PREVIEW_COMMAND = `\x0Ccheckpoint_paste()`;
-// \x0C: is Ctrl + L
 
 /**
  * Interactively previews the given Manim code by means of the


### PR DESCRIPTION
This PR attempts to fix the preview command on Windows. As seen in [this video](https://github.com/Manim-Notebook/manim-notebook/issues/18#issuecomment-2453048187), sometimes checkpoint_paste() is not executed in the IPython shell, but it triggers the multiline input in IPython. In this PR, I detect the multiline input ("...:") and send "\x7F" to clear the extra line and send another newline to actually execute the command. This seems to fix the issue on my side. Let me know if you have any issues on other platforms!

Fixes #18