### PR TITLE
add ability to start at construct method

### DIFF
--- a/src/startStopScene.ts
+++ b/src/startStopScene.ts
@@ -69,6 +69,24 @@ export async function startScene(lineStart?: number) {
         lineNumber--;
     }
 
+    // If current line contains: "def construct(" without "#" before it,
+    // then we insert a special comment line, and move the cursor to it
+    // (because `manimgl -se <lineNumber>` doesn't work on the "def construct(" line)
+    let idx = lines[lineNumber].indexOf("def construct(");
+    if (idx !== -1) {
+        if (lines[lineNumber].slice(0, idx).includes("#")) {
+            idx = -1;
+        }
+    }
+    if (idx !== -1) {
+        lineNumber++;
+        // Insert a comment line into editor at position `lineNumber`:
+        const HELPER_LINE = '        #';
+        const edit = new vscode.WorkspaceEdit();
+        edit.insert(editor.document.uri, new vscode.Position(lineNumber, 0), HELPER_LINE + "\n");
+        await vscode.workspace.applyEdit(edit);
+    }
+
     // Create the command
     const filePath = editor.document.fileName;  // absolute path
     const cmds = ["manimgl", `"${filePath}"`, sceneName];

--- a/src/startStopScene.ts
+++ b/src/startStopScene.ts
@@ -80,12 +80,14 @@ export async function startScene(lineStart?: number) {
     }
     if (idx !== -1) {
         lineNumber++;
-        // Insert a comment line into editor at position `lineNumber`:
         const HELPER_LINE = '        #';
-        const edit = new vscode.WorkspaceEdit();
-        edit.insert(editor.document.uri, new vscode.Position(lineNumber, 0), HELPER_LINE + "\n");
-        await vscode.workspace.applyEdit(edit);
-        await vscode.commands.executeCommand('workbench.action.files.save');
+        if (lines[lineNumber] !== HELPER_LINE) {
+            // Insert a HELPER_LINE into the editor at position `lineNumber`:
+            const edit = new vscode.WorkspaceEdit();
+            edit.insert(editor.document.uri, new vscode.Position(lineNumber, 0), HELPER_LINE + "\n");
+            await vscode.workspace.applyEdit(edit);
+            await vscode.commands.executeCommand('workbench.action.files.save');
+        }
     }
 
     // Create the command

--- a/src/startStopScene.ts
+++ b/src/startStopScene.ts
@@ -85,6 +85,7 @@ export async function startScene(lineStart?: number) {
         const edit = new vscode.WorkspaceEdit();
         edit.insert(editor.document.uri, new vscode.Position(lineNumber, 0), HELPER_LINE + "\n");
         await vscode.workspace.applyEdit(edit);
+        await vscode.commands.executeCommand('workbench.action.files.save');
     }
 
     // Create the command


### PR DESCRIPTION
added ability to start at the `construct` method
fixes #50

(Whenever the `manimgl` command starts supporting starting the scene on any of these lines, this PR can be reverted.)

<br />

## How I tested this PR:

```py
from manimlib import *

class MyScene(Scene):
    def construct(self):




        

        ## Test 1
        circle = Circle()
        self.play(ShowCreation(circle))
```

- put cursor on line 5  (at any position: in the middle or at the end of line)
- run the "manim notebook: start scene at cursor" command
- a comment `#` should appear right after the `def construct(` line, and manim notebook should start 
  (it runs the manimgl command with the line where this commend is)

<br />

- also, the same works when we start while the cursor is on line 6, or 7, or 8
  (which can be with or without arbitrary indents)