### PR TITLE
Detect non-interactive scene start (preview whole scene)

### DIFF
--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -359,6 +359,11 @@ export class ManimShell {
      * because another command needed to have a new shell started.
      * Only if the user manually starts a new scene, we want to exit a
      * potentially already running scene beforehand.
+     * @param shouldPreviewWholeScene Whether the command requests to preview
+     * the whole scene, i.e. without the `-se <lineNumber>` argument. In this
+     * case, we wait until an info message is shown in the terminal to detect
+     * when the whole scene has been previewed. Otherwise, we wait until the
+     * first IPython cell is found.
      */
     public async executeStartCommand(command: string,
         isRequestedForAnotherCommand: boolean, shouldPreviewWholeScene: boolean) {

--- a/src/startStopScene.ts
+++ b/src/startStopScene.ts
@@ -72,36 +72,18 @@ export async function startScene(lineStart?: number) {
     // Create the command
     const filePath = editor.document.fileName;  // absolute path
     const cmds = ["manimgl", `"${filePath}"`, sceneName];
-    let enter = false;
+    let shouldPreviewWholeScene = true;
     if (cursorLine !== matchingClass.index) {
+        // this is actually the more common case
+        shouldPreviewWholeScene = false;
         cmds.push(`-se ${lineNumber + 1}`);
-        enter = true;
     }
     const command = cmds.join(" ");
 
-    // // Commented out - in case someone would like it.
-    // // For us - we want to NOT overwrite our clipboard.
-    // // If one wants to run it in a different terminal,
-    // // it's often to write to a file
-    // await vscode.env.clipboard.writeText(command + " --prerun --finder -w");
-
     // Run the command
     const isRequestedForAnotherCommand = (lineStart !== undefined);
-    await ManimShell.instance.executeStartCommand(command, isRequestedForAnotherCommand);
-
-    // // Commented out - in case someone would like it.
-    // // For us - it would require MacOS. Also - the effect is not desired.
-    // // Focus some windows (ONLY for MacOS because it uses `osascript`!)
-    // const terminal = window.activeTerminal || window.createTerminal();
-    // if (enter) {
-    // 	// Keep cursor where it started (in VSCode)
-    // 	const cmd_focus_vscode = 'osascript -e "tell application \\"Visual Studio Code\\" to activate"';
-    // 	// Execute the command in the shell after a delay (to give the animation window enough time to open)
-    // 	await new Promise(resolve => setTimeout(resolve, 2500));
-    // 	require('child_process').exec(cmd_focus_vscode);
-    // } else {
-    // 	terminal.show();
-    // }
+    await ManimShell.instance.executeStartCommand(
+        command, isRequestedForAnotherCommand, shouldPreviewWholeScene);
 }
 
 /**


### PR DESCRIPTION
Fixes #84. When starting the scene at a Python "class definition line", we don't start ManimGL in interactive mode (with `-se <line_number>`). Instead the whole scene is previewed (see the behavior of `startStopScene.ts`). We now identify this scenario in the `executeStartCommand()` method and wait not for the first IPython cell to finish, but for the first log info message to be shown:

```
[17:39:31] INFO                                               scene.py:210
                    Tips: Using the keys `d`, `f`, or `z` you             
                    can interact with the scene. Press                    
                    `command + q` or `esc` to quit 
```


### Known limitations
- After issuing this command, we think that we are in an interactive environment. Therefore, the next `Preview Manim Cell` will just put `checkpoint_paste()` in the current terminal and therefore do nothing. But the next `Preview Manim Cell` will then succeed. If the user exits the shell after having previewed the whole scene, the next `Preview Manim Cell` will also work fine. I'd like to accept this as known limitation (or maybe if really needed tackle this case in a future PR where we should beforehand discuss what the expected behavior is in this case).