### PR TITLE
Init autoreload feature

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,6 +45,7 @@
         "ansi",
         "Ansi",
         "autoplay",
+        "autoreload",
         "cmds",
         "github",
         "ipython",
@@ -55,6 +56,7 @@
         "MANIM",
         "manimgl",
         "Sanderson's",
+        "venv",
         "youtube"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -106,6 +106,11 @@
     "configuration": {
       "title": "Manim Notebook",
       "properties": {
+        "manim-notebook.autoreload": {
+          "type": "boolean",
+          "default": "true",
+          "markdownDescription": "If enabled, Manim will be startup with the `--autoreload` flag, such that your imported Python modules are reloaded automatically in the background."
+        },
         "manim-notebook.clipboardTimeout": {
           "type": "number",
           "default": 650,

--- a/src/startStopScene.ts
+++ b/src/startStopScene.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { ManimShell, NoActiveShellError } from './manimShell';
-import { window } from 'vscode';
+import { window, workspace } from 'vscode';
 import { Logger, Window } from './logger';
 import { findClassLines, findManimSceneName } from './pythonParsing';
 
@@ -64,6 +64,10 @@ export async function startScene(lineStart?: number) {
         // this is actually the more common case
         shouldPreviewWholeScene = false;
         cmds.push(`-se ${lineNumber + 1}`);
+    }
+    const autoreload = await workspace.getConfiguration("manim-notebook").get("autoreload");
+    if (autoreload) {
+        cmds.push("--autoreload");
     }
     const command = cmds.join(" ");
 


### PR DESCRIPTION
3b1b and me added a new `--autoreload` CLI flag to Manim in https://github.com/3b1b/manim/pull/2268. See https://github.com/3b1b/manim/pull/2252 for a detailed description of what it is about and also some test code to experiment with.

In this PR, we bring this new flag to Manim Notebook and activate it by default since its performance penalty is really negligible. 

