### PR TITLE
Fix remaining ESLint errors (manually)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -82,8 +82,11 @@
     "MANIM",
     "manimgl",
     "Millis",
+    "prerun",
+    "Sanderson",
     "Sanderson's",
     "venv",
+    "virtualenvs",
     "youtube"
   ]
 }

--- a/src/export.ts
+++ b/src/export.ts
@@ -1,8 +1,7 @@
 import * as vscode from "vscode";
-import { QuickPickItem, window } from "vscode";
+import { window, TextDocument, CancellationToken, CodeLens } from "vscode";
 import {
-  MultiStepInput, toQuickPickItem, toQuickPickItems,
-  shouldResumeNoOp,
+  MultiStepInput, toQuickPickItems, shouldResumeNoOp,
 } from "./utils/multiStepQuickPickUtil";
 import { findClassLines, findManimSceneName } from "./pythonParsing";
 import { Logger, Window } from "./logger";
@@ -14,11 +13,12 @@ class VideoQuality {
   static readonly HIGH = new VideoQuality("High Quality (1080p)", "--hd");
   static readonly VERY_HIGH = new VideoQuality("Very High Quality (4K)", "--uhd");
 
+  // eslint-disable-next-line no-unused-vars
   private constructor(public readonly name: string, public readonly cliFlag: string) { }
 
   /**
-     * Returns the names of all VideoQuality objects.
-     */
+   * Returns the names of all VideoQuality objects.
+   */
   static names(): string[] {
     return Object.values(VideoQuality).map(quality => quality.name);
   }
@@ -69,8 +69,8 @@ export async function exportScene(sceneName?: string) {
   const QUICK_PICK_TITLE = "Export scene as video";
 
   /**
-     * Lets the user pick the quality of the video to export.
-     */
+   * Lets the user pick the quality of the video to export.
+   */
   async function pickQuality(input: MultiStepInput, state: Partial<VideoSettings>) {
     const qualityPick = await input.showQuickPick({
       title: QUICK_PICK_TITLE,
@@ -86,8 +86,8 @@ export async function exportScene(sceneName?: string) {
   }
 
   /**
-     * Lets the user pick the frames per second (fps) of the video to export.
-     */
+   * Lets the user pick the frames per second (fps) of the video to export.
+   */
   async function pickFps(input: MultiStepInput, state: Partial<VideoSettings>) {
     const fps = await input.showInputBox({
       title: QUICK_PICK_TITLE,
@@ -114,12 +114,12 @@ export async function exportScene(sceneName?: string) {
   }
 
   /**
-     * Lets the user pick the filename of the video to export. The default value
-     * is the name of the scene followed by ".mp4".
-     *
-     * It is ok to not append `.mp4` here as Manim will also do it if it is not
-     * present in the filename.
-     */
+   * Lets the user pick the filename of the video to export. The default value
+   * is the name of the scene followed by ".mp4".
+   *
+   * It is ok to not append `.mp4` here as Manim will also do it if it is not
+   * present in the filename.
+   */
   async function pickFileName(input: MultiStepInput, state: Partial<VideoSettings>) {
     const fileName = await input.showInputBox({
       title: QUICK_PICK_TITLE,
@@ -152,8 +152,8 @@ export async function exportScene(sceneName?: string) {
   }
 
   /**
-     * Lets the user pick the folder location where the video should be saved.
-     */
+   * Lets the user pick the folder location where the video should be saved.
+   */
   async function pickFileLocation(input: MultiStepInput, state: Partial<VideoSettings>) {
     const folderUri = await window.showOpenDialog({
       canSelectFiles: false,
@@ -168,9 +168,9 @@ export async function exportScene(sceneName?: string) {
   }
 
   /**
-     * Initiates the multi-step wizard and returns the collected inputs
-     * from the user.
-     */
+   * Initiates the multi-step wizard and returns the collected inputs
+   * from the user.
+   */
   async function collectInputs(): Promise<VideoSettings> {
     const state = {} as Partial<VideoSettings>;
     state.sceneName = sceneName;
@@ -225,7 +225,7 @@ function toManimExportCommand(settings: VideoSettings, editor: vscode.TextEditor
  * class definition line in the active document.
  */
 export class ExportSceneCodeLens implements vscode.CodeLensProvider {
-  public provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.CodeLens[] {
+  public provideCodeLenses(document: TextDocument, _token: CancellationToken): CodeLens[] {
     const codeLenses: vscode.CodeLens[] = [];
 
     for (const classLine of findClassLines(document)) {
@@ -242,7 +242,7 @@ export class ExportSceneCodeLens implements vscode.CodeLensProvider {
     return codeLenses;
   }
 
-  public resolveCodeLens(codeLens: vscode.CodeLens, token: vscode.CancellationToken): vscode.CodeLens {
+  public resolveCodeLens(codeLens: CodeLens, _token: CancellationToken): CodeLens {
     return codeLens;
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,6 @@ import { window } from "vscode";
 import { ManimShell, NoActiveShellError } from "./manimShell";
 import { ManimCell } from "./manimCell";
 import { previewManimCell, reloadAndPreviewManimCell, previewCode } from "./previewCode";
-import { ManimCellRanges } from "./pythonParsing";
 import { startScene, exitScene } from "./startStopScene";
 import { exportScene } from "./export";
 import { Logger, Window, LogRecorder } from "./logger";
@@ -114,6 +113,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     previewManimCellCommand,
     previewSelectionCommand,
+    reloadAndPreviewManimCellCommand,
     startSceneCommand,
     exitSceneCommand,
     clearSceneCommand,
@@ -134,7 +134,7 @@ export function deactivate() {
 /**
  * Previews the selected code.
  *
- * - both ends of the selection automatically extend to the start and end of lines
+ * - both ends of the selection automatically extend to the start & end of lines
  *   (for convenience)
  * - if Multi-Cursor selection:
  *   only the first selection is considered

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -54,11 +54,11 @@ export class Logger {
   }
 
   /**
-     * Clears the output panel and the log file. This is necessary since clearing
-     * is not performed automatically on MacOS. See issue #58.
-     *
-     * @param logFilePath The URI of the log file.
-     */
+   * Clears the output panel and the log file. This is necessary since clearing
+   * is not performed automatically on MacOS. See issue #58.
+   *
+   * @param logFilePath The URI of the log file.
+   */
   public static async clear(logFilePath: vscode.Uri) {
     // This logging statement here is important to ensure that something
     // is written to the log file, such that the file is created on disk.
@@ -82,31 +82,32 @@ export class Logger {
   }
 
   /**
-     * Returns formatted caller information in the form of
-     * "[filename] [methodname]".
-     *
-     * It works by creating a stack trace and extracting the file name from the
-     * third line of the stack trace, e.g.
-     *
-     * Error:
-     *      at Logger.getCurrentFileName (manim-notebook/out/logger.js:32:19)
-     *      at Logger.info (manim-notebook/out/logger.js:46:39)
-     *      at activate (manim-notebook/out/extension.js:37:21)
-     * ...
-     *
-     * where "extension.js:37:21" is the file that called the logger method
-     * and "activate" is the respective method.
-     *
-     * Another example where the Logger is called in a Promise might be:
-     *
-     * Error:
-     *     at Function.getFormattedCallerInformation (manim-notebook/src/logger.ts:46:23)
-     *     at Function.info (manim-notebook/src/logger.ts:18:31)
-     *     at manim-notebook/src/extension.ts:199:12
-     *
-     * where "extension.ts:199:12" is the file that called the logger method
-     * and the method is unknown.
-     */
+   * Returns formatted caller information in the form of
+   * "[filename] [methodname]".
+   *
+   * It works by creating a stack trace and extracting the file name from the
+   * third line of the stack trace, e.g.
+   *
+   * Error:
+   *      at Logger.getCurrentFileName (manim-notebook/out/logger.js:32:19)
+   *      at Logger.info (manim-notebook/out/logger.js:46:39)
+   *      at activate (manim-notebook/out/extension.js:37:21)
+   * ...
+   *
+   * where "extension.js:37:21" is the file that called the logger method
+   * and "activate" is the respective method.
+   *
+   * Another example where the Logger is called in a Promise might be:
+   *
+   * Error:
+   *   at Function.getFormattedCallerInformation
+   *      (manim-notebook/src/logger.ts:46:23)
+   *   at Function.info (manim-notebook/src/logger.ts:18:31)
+   *   at manim-notebook/src/extension.ts:199:12
+   *
+   * where "extension.ts:199:12" is the file that called the logger method
+   * and the method is unknown.
+   */
   private static getFormattedCallerInformation(): string {
     const error = new Error();
     const stack = error.stack;
@@ -173,11 +174,11 @@ export class LogRecorder {
   private static recorderStatusBar: vscode.StatusBarItem;
 
   /**
-     * Starts recording a log file. Initializes a new status bar item that
-     * allows the user to stop the recording.
-     *
-     * @param context The extension context.
-     */
+   * Starts recording a log file. Initializes a new status bar item that
+   * allows the user to stop the recording.
+   *
+   * @param context The extension context.
+   */
   public static async recordLogFile(context: vscode.ExtensionContext) {
     if (Logger.isRecording) {
       window.showInformationMessage("A log file is already being recorded.");
@@ -191,7 +192,7 @@ export class LogRecorder {
       location: vscode.ProgressLocation.Notification,
       title: "Setting up Manim Notebook Log recording...",
       cancellable: false,
-    }, async (progressIndicator, token) => {
+    }, async (_progressIndicator, _token) => {
       try {
         await Logger.clear(this.getLogFilePath(context));
         isClearSuccessful = true;
@@ -225,11 +226,11 @@ export class LogRecorder {
   }
 
   /**
-     * Finishes the active recording of a log file. Called when the user
-     * clicks on the status bar item initialized in `recordLogFile()`.
-     *
-     * @param context The extension context.
-     */
+   * Finishes the active recording of a log file. Called when the user
+   * clicks on the status bar item initialized in `recordLogFile()`.
+   *
+   * @param context The extension context.
+   */
   public static async finishRecordingLogFile(context: vscode.ExtensionContext) {
     Logger.isRecording = false;
     this.recorderStatusBar.dispose();
@@ -238,25 +239,26 @@ export class LogRecorder {
   }
 
   /**
-     * Returns the URI of the log file that VSCode initializes for us.
-     *
-     * @param context The extension context.
-     */
+   * Returns the URI of the log file that VSCode initializes for us.
+   *
+   * @param context The extension context.
+   */
   private static getLogFilePath(context: vscode.ExtensionContext): vscode.Uri {
     return vscode.Uri.joinPath(context.logUri, `${LOGGER_NAME}.log`);
   }
 
   /**
-     * Tries to open the log file in an editor and reveal it in the OS file explorer.
-     *
-     * @param logFilePath The URI of the log file.
-     */
+   * Tries to open the log file in an editor and reveal it in the
+   * OS file explorer.
+   *
+   * @param logFilePath The URI of the log file.
+   */
   private static async openLogFile(logFilePath: vscode.Uri) {
     await window.withProgress({
       location: vscode.ProgressLocation.Notification,
       title: "Opening Manim Notebook log file...",
       cancellable: false,
-    }, async (progressIndicator, token) => {
+    }, async (_progressIndicator, _token) => {
       await new Promise<void>(async (resolve) => {
         try {
           const doc = await vscode.workspace.openTextDocument(logFilePath);

--- a/src/manimCell.ts
+++ b/src/manimCell.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
-import { window } from "vscode";
+import { window, TextDocument, CancellationToken,
+  CodeLens, FoldingContext, FoldingRange } from "vscode";
 import { ManimCellRanges } from "./pythonParsing";
 
 export class ManimCell implements vscode.CodeLensProvider, vscode.FoldingRangeProvider {
@@ -34,7 +35,7 @@ export class ManimCell implements vscode.CodeLensProvider, vscode.FoldingRangePr
     });
   }
 
-  public provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.CodeLens[] {
+  public provideCodeLenses(document: TextDocument, _token: CancellationToken): CodeLens[] {
     if (!window.activeTextEditor) {
       return [];
     }
@@ -71,7 +72,10 @@ export class ManimCell implements vscode.CodeLensProvider, vscode.FoldingRangePr
     return codeLenses;
   }
 
-  public provideFoldingRanges(document: vscode.TextDocument, context: vscode.FoldingContext, token: vscode.CancellationToken): vscode.FoldingRange[] {
+  public provideFoldingRanges(
+    document: TextDocument,
+    _context: FoldingContext,
+    _token: CancellationToken): FoldingRange[] {
     const ranges = ManimCellRanges.calculateRanges(document);
     return ranges.map(range => new vscode.FoldingRange(range.start.line, range.end.line));
   }

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -51,23 +51,27 @@ enum ManimShellEvent {
    * Event emitted when an IPython cell has finished executing, i.e. when the
    * IPYTHON_CELL_START_REGEX is matched.
    */
+  // eslint-disable-next-line no-unused-vars
   IPYTHON_CELL_FINISHED = "ipythonCellFinished",
 
   /**
    * Event emitted when a log info message is detected in the terminal.
    */
+  // eslint-disable-next-line no-unused-vars
   LOG_INFO_MESSAGE = "logInfoMessage",
 
   /**
    * Event emitted when a keyboard interrupt is detected in the terminal, e.g.
    * when `Ctrl+C` is pressed to stop the current command execution.
    */
+  // eslint-disable-next-line no-unused-vars
   KEYBOARD_INTERRUPT = "keyboardInterrupt",
 
   /**
    * Event emitted when data is received from the terminal, but stripped of
    * ANSI control codes.
    */
+  // eslint-disable-next-line no-unused-vars
   DATA = "ansiStrippedData",
 
   /**
@@ -75,11 +79,13 @@ enum ManimShellEvent {
    * execution has ended before we have detected the start of the ManimGL
    * session.
    */
+  // eslint-disable-next-line no-unused-vars
   MANIM_NOT_STARTED = "manimglNotStarted",
 
   /**
    * Event emitted when the active shell is reset.
    */
+  // eslint-disable-next-line no-unused-vars
   RESET = "reset",
 }
 
@@ -97,7 +103,7 @@ export interface CommandExecutionEventHandler {
    * during Manim startup), the shell might not exist anymore after the
    * command was issued.
    */
-  onCommandIssued?: (shellStillExists: boolean) => void;
+  onCommandIssued?: (_shellStillExists: boolean) => void;
 
   /**
    * Callback that is invoked when data is received from the active Manim
@@ -106,7 +112,7 @@ export interface CommandExecutionEventHandler {
    * @param data The data that was received from the terminal, but stripped
    * of ANSI control codes.
    */
-  onData?: (data: string) => void;
+  onData?: (_data: string) => void;
 
   /**
    * Callback that is invoked when the manim shell is reset. This indicates
@@ -439,7 +445,7 @@ export class ManimShell {
         ? "Previewing whole scene..."
         : "Starting Manim...",
       cancellable: false,
-    }, async (progress, token) => {
+    }, async (_progress, _token) => {
       // We are sure that the active shell is set since it is invoked
       // in `retrieveOrInitActiveShell()` or in the line above.
       this.shellWeTryToSpawnIn = this.activeShell;

--- a/src/manimVersion.ts
+++ b/src/manimVersion.ts
@@ -7,7 +7,8 @@ import { ManimShell } from "./manimShell";
 import { manimNotebookContext } from "./extension";
 
 /**
- * Manim version that the user has installed without the 'v' prefix, e.g. '1.2.3'.
+ * Manim version that the user has installed without the 'v' prefix,
+ * e.g. '1.2.3'.
  */
 let MANIM_VERSION: string | undefined;
 let isCanceledByUser = false;
@@ -99,8 +100,8 @@ export async function hasUserMinimalManimVersion(requiredVersion: string): Promi
 }
 
 /**
- * Returns the tag name of the latest Manim release if the GitHub API is reachable.
- * This tag name won't include the 'v' prefix, e.g. '1.2.3'.
+ * Returns the tag name of the latest Manim release if the GitHub API is
+ * reachable. This tag name won't include the 'v' prefix, e.g. '1.2.3'.
  */
 async function fetchLatestManimVersion(): Promise<string | undefined> {
   const url = "https://api.github.com/repos/3b1b/manim/releases/latest";
@@ -222,7 +223,8 @@ async function showNegativeUserVersionFeedback(isAtStartup: boolean) {
  * Constructs a promise that times out after the given time and reports progress
  * automatically in the meantime every 500ms.
  *
- * @param timeout The time in milliseconds after which the promise should time out.
+ * @param timeout The time in milliseconds after which the promise
+ *                should time out.
  * @param progress The progress indicator to report to.
  * @param token The cancellation token to listen to.
  * @returns A promise that times out after the given time.

--- a/src/manimVersion.ts
+++ b/src/manimVersion.ts
@@ -1,7 +1,6 @@
 import * as vscode from "vscode";
 import { window } from "vscode";
-import { waitNewTerminalDelay, withoutAnsiCodes, onTerminalOutput } from "./utils/terminal";
-import { EventEmitter } from "events";
+import { waitNewTerminalDelay, onTerminalOutput } from "./utils/terminal";
 import { Window, Logger } from "./logger";
 import { ManimShell } from "./manimShell";
 import { manimNotebookContext } from "./extension";
@@ -154,7 +153,7 @@ export async function tryToDetermineManimVersion(isAtStartup = false) {
     cancellable: true,
   }, async (progress, token) => {
     try {
-      couldDetermineManimVersion = await new Promise<boolean>(async (resolve, reject) => {
+      couldDetermineManimVersion = await new Promise<boolean>(async (resolve, _reject) => {
         progress.report({ increment: 0 });
 
         ManimShell.instance.lockManimWelcomeStringDetection = true;
@@ -262,7 +261,7 @@ function constructTimeoutPromise(
  * `MANIM_VERSION` variable. False otherwise.
  */
 async function lookForManimVersionString(terminal: vscode.Terminal): Promise<boolean> {
-  return new Promise<boolean>(async (resolve, reject) => {
+  return new Promise<boolean>(async (resolve, _reject) => {
     onTerminalOutput(terminal, (data: string) => {
       const versionMatch = data.match(/^\s*ManimGL v([0-9]+\.[0-9]+\.[0-9]+)/);
       if (!versionMatch) {

--- a/src/previewCode.ts
+++ b/src/previewCode.ts
@@ -170,7 +170,7 @@ class PreviewProgress {
       location: vscode.ProgressLocation.Notification,
       title: "Previewing Manim",
       cancellable: false,
-    }, async (progressIndicator, token) => {
+    }, async (progressIndicator, _token) => {
       await new Promise((resolve) => {
         this.eventEmitter.on(this.FINISH_EVENT, resolve);
         this.eventEmitter.on(this.REPORT_EVENT,

--- a/src/previewCode.ts
+++ b/src/previewCode.ts
@@ -48,8 +48,10 @@ function parsePreviewCellArgs(cellCode?: string, startLine?: number) {
  * A Manim cell starts with `##`.
  *
  * This can be invoked by either:
- * - clicking the code lens (the button above the cell) -> this cell is previewed
- * - command pallette -> the 1 cell where the cursor is is previewed
+ * - clicking the code lens (the button above the cell)
+ *   -> this cell is previewed
+ * - command pallette
+ *   -> the 1 cell where the cursor is is previewed
  *
  * If Manim isn't running, it will be automatically started
  * (at the start of the cell which will be previewed: on its starting ## line),
@@ -97,7 +99,8 @@ export async function reloadAndPreviewManimCell(cellCode?: string, startLine?: n
  * [2] https://github.com/ManimCommunity/manim/discussions/3954#discussioncomment-10933720
  * [3] https://youtu.be/rbu7Zu5X1zI
  *
- * @param code The code to preview (e.g. from a Manim cell or from a custom selection).
+ * @param code The code to preview (e.g. from a Manim cell or from a
+ *             custom selection).
  * @param startLine The line number in the active editor where the Manim session
  * should start in case a new terminal is spawned. Also see `startScene().
  */
@@ -153,13 +156,13 @@ class PreviewProgress {
   private REPORT_EVENT = "report";
 
   /**
-     * Current progress of the preview command.
-     */
+   * Current progress of the preview command.
+   */
   private progress: number = 0;
 
   /**
-     * Name of the animation being previewed.
-     */
+   * Name of the animation being previewed.
+   */
   private animationName: string | undefined;
 
   constructor() {
@@ -184,11 +187,11 @@ class PreviewProgress {
   }
 
   /**
-     * Updates the progress based on the given Manim preview output.
-     * E.g. `2 ShowCreationNumberPlane, etc.:   7%| 2  /30  16.03it/s`
-     *
-     * @param data The Manim preview output to parse.
-     */
+   * Updates the progress based on the given Manim preview output.
+   * E.g. `2 ShowCreationNumberPlane, etc.:   7%| 2  /30  16.03it/s`
+   *
+   * @param data The Manim preview output to parse.
+   */
   public reportOnData(data: string) {
     const newProgress = this.extractProgressFromString(data);
     if (newProgress === -1) {
@@ -217,20 +220,20 @@ class PreviewProgress {
   }
 
   /**
-     * Finishes the progress notification, i.e. closes the progress bar.
-     */
+   * Finishes the progress notification, i.e. closes the progress bar.
+   */
   public finish() {
     Logger.debug("📊 Finishing progress notification");
     this.eventEmitter.emit(this.FINISH_EVENT);
   }
 
   /**
-     * Extracts the progress information from the given Manim preview output.
-     *
-     * @param data The Manim preview output to parse.
-     * @returns The progress percentage as in the interval [0, 100],
-     * or -1 if no progress information was found.
-     */
+   * Extracts the progress information from the given Manim preview output.
+   *
+   * @param data The Manim preview output to parse.
+   * @returns The progress percentage as in the interval [0, 100],
+   * or -1 if no progress information was found.
+   */
   private extractProgressFromString(data: string): number {
     if (!data.includes("%")) {
       return -1;

--- a/src/pythonParsing.ts
+++ b/src/pythonParsing.ts
@@ -1,29 +1,30 @@
 import * as vscode from "vscode";
+import { TextDocument } from "vscode";
 
 export class ManimCellRanges {
   /**
-     * Regular expression to match the start of a Manim cell.
-     *
-     * The marker is a comment line starting with "##". Since the comment might
-     * be indented, we allow for any number of leading whitespaces.
-     *
-     * Manim cells themselves might contain further comments, but no nested
-     * Manim cells, i.e. no further comment starting with "##".
-     */
+   * Regular expression to match the start of a Manim cell.
+   *
+   * The marker is a comment line starting with "##". Since the comment might
+   * be indented, we allow for any number of leading whitespaces.
+   *
+   * Manim cells themselves might contain further comments, but no nested
+   * Manim cells, i.e. no further comment starting with "##".
+   */
   private static readonly MARKER = /^(\s*##)/;
 
   /**
-     * Calculates the ranges of Manim cells in the given document.
-     *
-     * A new Manim cell starts at a custom MARKER. The cell ends either:
-     * - when the next line starts with the MARKER
-     * - when the indentation level decreases
-     * - at the end of the document
-     *
-     * This method is performance-intensive as it has to go through every single
-     * line of the document. Despite this, we call it many times and caching
-     * could be beneficial in the future.
-     */
+   * Calculates the ranges of Manim cells in the given document.
+   *
+   * A new Manim cell starts at a custom MARKER. The cell ends either:
+   * - when the next line starts with the MARKER
+   * - when the indentation level decreases
+   * - at the end of the document
+   *
+   * This method is performance-intensive as it has to go through every single
+   * line of the document. Despite this, we call it many times and caching
+   * could be beneficial in the future.
+   */
   public static calculateRanges(document: vscode.TextDocument): vscode.Range[] {
     const ranges: vscode.Range[] = [];
     let start: number | null = null;
@@ -59,12 +60,12 @@ export class ManimCellRanges {
   }
 
   /**
-     * Returns the cell range that contains the given line number.
-     *
-     * Returns null if no cell range contains the line, e.g. if the cursor is
-     * outside of a Manim cell.
-     */
-  public static getCellRangeAtLine(document: vscode.TextDocument, line: number): vscode.Range | null {
+   * Returns the cell range that contains the given line number.
+   *
+   * Returns null if no cell range contains the line, e.g. if the cursor is
+   * outside of a Manim cell.
+   */
+  public static getCellRangeAtLine(document: TextDocument, line: number): vscode.Range | null {
     const ranges = ManimCellRanges.calculateRanges(document);
     for (const range of ranges) {
       if (range.start.line <= line && line <= range.end.line) {
@@ -75,9 +76,9 @@ export class ManimCellRanges {
   }
 
   /**
-     * Constructs a new cell range from the given start and end line numbers.
-     * Discards all trailing empty lines at the end of the range.
-     */
+   * Constructs a new cell range from the given start and end line numbers.
+   * Discards all trailing empty lines at the end of the range.
+   */
   private static getRangeDiscardEmpty(
     document: vscode.TextDocument, start: number, end: number,
   ): vscode.Range {
@@ -124,7 +125,7 @@ export function findClassLines(document: vscode.TextDocument): ClassLine[] {
  * @param cursorLine The line number of the cursor.
  * @returns The ClassLine associated to the Manim scene, or null if not found.
  */
-export function findManimSceneName(document: vscode.TextDocument, cursorLine: number): ClassLine | null {
+export function findManimSceneName(document: TextDocument, cursorLine: number): ClassLine | null {
   const classLines = findClassLines(document);
   const matchingClass = classLines
     .reverse()

--- a/src/startStopScene.ts
+++ b/src/startStopScene.ts
@@ -2,12 +2,12 @@ import * as vscode from "vscode";
 import { ManimShell, NoActiveShellError } from "./manimShell";
 import { window, workspace } from "vscode";
 import { Logger, Window } from "./logger";
-import { findClassLines, findManimSceneName } from "./pythonParsing";
+import { findManimSceneName } from "./pythonParsing";
 import { isAtLeastManimVersion } from "./manimVersion";
 
 /**
- * Runs the `manimgl` command in the terminal, with the current cursor's line number:
- * manimgl <file_name> <ClassName> [-se <lineNumber>]
+ * Runs the `manimgl` command in the terminal, with the current cursor's
+ * line number: manimgl <file_name> <ClassName> [-se <lineNumber>]
  *
  * - Saves the active file.
  * - Previews the scene at the cursor's line (end of line)
@@ -42,7 +42,6 @@ export async function startScene(lineStart?: number) {
   }
 
   const lines = editor.document.getText().split("\n");
-  const classLines = findClassLines(editor.document);
   let cursorLine = lineStart || editor.selection.start.line;
   const sceneClassLine = findManimSceneName(editor.document, cursorLine);
   if (!sceneClassLine) {

--- a/src/utils/multiStepQuickPickUtil.ts
+++ b/src/utils/multiStepQuickPickUtil.ts
@@ -1,6 +1,5 @@
 import {
-  QuickPickItem, window, Disposable, CancellationToken, QuickInputButton,
-  QuickInput, ExtensionContext, QuickInputButtons, Uri,
+  QuickPickItem, window, Disposable, QuickInputButton, QuickInput, QuickInputButtons,
 } from "vscode";
 
 export function toQuickPickItem(names: string): QuickPickItem {
@@ -46,7 +45,7 @@ class InputFlowAction {
   static resume = new InputFlowAction();
 }
 
-type InputStep = (input: MultiStepInput) => Thenable<InputStep | void>;
+type InputStep = (_input: MultiStepInput) => Thenable<InputStep | void>;
 
 interface QuickPickParameters<T extends QuickPickItem> {
   title: string;
@@ -66,7 +65,7 @@ interface InputBoxParameters {
   totalSteps: number;
   value: string;
   prompt: string;
-  validate: (value: string) => Promise<string | undefined>;
+  validate: (_value: string) => Promise<string | undefined>;
   buttons?: QuickInputButton[];
   ignoreFocusOut?: boolean;
   placeholder?: string;
@@ -110,10 +109,13 @@ export class MultiStepInput {
     }
   }
 
-  async showQuickPick<T extends QuickPickItem, P extends QuickPickParameters<T>>({ title, step, totalSteps, items, activeItem, ignoreFocusOut, placeholder, buttons, shouldResume }: P) {
+  async showQuickPick<T extends QuickPickItem, P extends QuickPickParameters<T>>(
+    { title, step, totalSteps, items, activeItem, ignoreFocusOut,
+      placeholder, buttons, shouldResume }: P) {
     const disposables: Disposable[] = [];
     try {
-      return await new Promise<T | (P extends { buttons: (infer I)[] } ? I : never)>((resolve, reject) => {
+      return await
+      new Promise<T | (P extends { buttons: (infer I)[] } ? I : never)>((resolve, reject) => {
         const input = window.createQuickPick<T>();
         input.title = title;
         input.step = step;
@@ -133,14 +135,15 @@ export class MultiStepInput {
             if (item === QuickInputButtons.Back) {
               reject(InputFlowAction.back);
             } else {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               resolve((item as any));
             }
           }),
           input.onDidChangeSelection(items => resolve(items[0])),
           input.onDidHide(() => {
             (async () => {
-              reject(shouldResume && await shouldResume() ? InputFlowAction.resume : InputFlowAction.cancel);
+              reject(shouldResume && await shouldResume()
+                ? InputFlowAction.resume
+                : InputFlowAction.cancel);
             })()
               .catch(reject);
           }),
@@ -156,10 +159,13 @@ export class MultiStepInput {
     }
   }
 
-  async showInputBox<P extends InputBoxParameters>({ title, step, totalSteps, value, prompt, validate, buttons, ignoreFocusOut, placeholder, shouldResume }: P) {
+  async showInputBox<P extends InputBoxParameters>(
+    { title, step, totalSteps, value, prompt, validate,
+      buttons, ignoreFocusOut, placeholder, shouldResume }: P) {
     const disposables: Disposable[] = [];
     try {
-      return await new Promise<string | (P extends { buttons: (infer I)[] } ? I : never)>((resolve, reject) => {
+      return await
+      new Promise<string | (P extends { buttons: (infer I)[] } ? I : never)>((resolve, reject) => {
         const input = window.createInputBox();
         input.title = title;
         input.step = step;
@@ -178,7 +184,6 @@ export class MultiStepInput {
             if (item === QuickInputButtons.Back) {
               reject(InputFlowAction.back);
             } else {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               resolve(item as any);
             }
           }),
@@ -202,7 +207,9 @@ export class MultiStepInput {
           }),
           input.onDidHide(() => {
             (async () => {
-              reject(shouldResume && await shouldResume() ? InputFlowAction.resume : InputFlowAction.cancel);
+              reject(shouldResume && await shouldResume()
+                ? InputFlowAction.resume
+                : InputFlowAction.cancel);
             })()
               .catch(reject);
           }),

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -20,7 +20,7 @@ export async function waitNewTerminalDelay() {
       location: vscode.ProgressLocation.Notification,
       title: "Waiting a user-defined delay for the new terminal...",
       cancellable: false,
-    }, async (progress, token) => {
+    }, async (progress, _token) => {
       progress.report({ increment: 0 });
 
       // split user-defined timeout into 500ms chunks and show progress
@@ -68,7 +68,7 @@ export async function* withoutAnsiCodes(stream: AsyncIterable<string>): AsyncIte
  * @param withoutAnsi Whether to clean the output from ANSI control codes.
  */
 export async function onTerminalOutput(
-  terminal: vscode.Terminal, callback: (data: string) => void, withoutAnsi = true) {
+  terminal: vscode.Terminal, callback: (_data: string) => void, withoutAnsi = true) {
   window.onDidStartTerminalShellExecution(
     async (event: vscode.TerminalShellExecutionStartEvent) => {
       if (event.terminal !== terminal) {

--- a/src/walkthrough/commands.ts
+++ b/src/walkthrough/commands.ts
@@ -1,7 +1,6 @@
 import * as vscode from "vscode";
-import { ExtensionContext, window, workspace, commands, extensions } from "vscode";
-import { Logger, Window } from "../logger";
-import { ManimShell } from "../manimShell";
+import { ExtensionContext, window, workspace, commands } from "vscode";
+import { Logger } from "../logger";
 import fs from "fs";
 import path from "path";
 
@@ -50,7 +49,7 @@ export function registerWalkthroughCommands(context: ExtensionContext) {
 }
 
 /**
- * Opens a sample Manim file in a new editor that the user can use to get started.
+ * Opens a sample Manim file in a new editor that users can use to get started.
  *
  * @param context The extension context.
  */


### PR DESCRIPTION
This is a follow up to #104 and #103 and fixes the remaining ESLint errors (e.g. by manually breaking up a line that was too long beforehand). We also fix the indentation of many docstrings.