### PR TITLE
Allow users to define custom marker cells

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,11 @@
           "type": "boolean",
           "default": true,
           "markdownDescription": "If enabled, the start comment of each cell (comment that begins with `##`) will be typeset in bold."
+        },
+        "manim-notebook.cellMarker": {
+          "type": "string",
+          "default": "##",
+          "markdownDescription": "The marker that indicates the start of a Manim cell in a plain text python file."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
         "manim-notebook.typesetStartCommentInBold": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "If enabled, the start comment of each cell (comment that begins with `##`) will be typeset in bold."
+          "markdownDescription": "If enabled, the start comment of each cell (e.g., comment that begins with `##`) will be typeset in bold."
         },
         "manim-notebook.cellMarker": {
           "type": "string",
@@ -156,7 +156,7 @@
     "colors": [
       {
         "id": "manimNotebookColors.baseColor",
-        "description": "Base color used for the Manim cell border and the respective start comment (comment that begins with `##`).",
+        "description": "Base color used for the Manim cell border and the respective start comment (e.g., comment that begins with `##`).",
         "defaults": {
           "dark": "#64A4ED",
           "light": "#2B7BD6",

--- a/src/previewCode.ts
+++ b/src/previewCode.ts
@@ -45,7 +45,7 @@ function parsePreviewCellArgs(cellCode?: string, startLine?: number) {
 /**
  * Previews all code inside of a Manim cell.
  *
- * A Manim cell starts with `##`.
+ * A Manim cell starts with `##` by default.
  *
  * This can be invoked by either:
  * - clicking the code lens (the button above the cell)
@@ -54,7 +54,7 @@ function parsePreviewCellArgs(cellCode?: string, startLine?: number) {
  *   -> the 1 cell where the cursor is is previewed
  *
  * If Manim isn't running, it will be automatically started
- * (at the start of the cell which will be previewed: on its starting ## line),
+ * (at the start of the cell which will be previewed: e.g., on its starting ## line),
  * and then this cell is previewed.
  */
 export async function previewManimCell(cellCode?: string, startLine?: number) {

--- a/src/pythonParsing.ts
+++ b/src/pythonParsing.ts
@@ -5,11 +5,11 @@ export class ManimCellRanges {
   /**
    * Regular expression to match the start of a Manim cell.
    *
-   * The marker is a comment line starting with "##". Since the comment might
+   * By default, the cell marker is a comment line starting with "##". Since the comment might
    * be indented, we allow for any number of leading whitespaces.
    *
    * Manim cells themselves might contain further comments, but no nested
-   * Manim cells, i.e. no further comment starting with "##".
+   * Manim cells, i.e. no further comment starting with the default "##".
    */
   private static readonly MARKER = new RegExp(
     `^(\\s*${vscode.workspace.getConfiguration("manim-notebook").cellMarker})`,

--- a/src/pythonParsing.ts
+++ b/src/pythonParsing.ts
@@ -11,10 +11,10 @@ export class ManimCellRanges {
    * Manim cells themselves might contain further comments, but no nested
    * Manim cells, i.e. no further comment starting with the default "##".
    */
-  private static readonly MARKER = new RegExp(
-    `^(\\s*${vscode.workspace.getConfiguration("manim-notebook").cellMarker})`,
-  );
-
+  private static get MARKER(): RegExp {
+    const cellMarker = vscode.workspace.getConfiguration("manim-notebook").cellMarker;
+    return new RegExp(`^(\\s*${cellMarker})`);
+  } 
   /**
    * Calculates the ranges of Manim cells in the given document.
    *

--- a/src/pythonParsing.ts
+++ b/src/pythonParsing.ts
@@ -11,7 +11,9 @@ export class ManimCellRanges {
    * Manim cells themselves might contain further comments, but no nested
    * Manim cells, i.e. no further comment starting with "##".
    */
-  private static readonly MARKER = /^(\s*##)/;
+  private static readonly MARKER = new RegExp(
+    `^(\\s*${vscode.workspace.getConfiguration("manim-notebook").cellMarker})`,
+  );
 
   /**
    * Calculates the ranges of Manim cells in the given document.


### PR DESCRIPTION
Expose the `manim-cellMarker` (which defaults to `##`) as a user-configurable option. A possible solution to #12, since it allows users to define a cell marker that would not clash with their other python files.

**Proposal**. @splines, this is not yet implemented but I would like your feedback. In the spirit of minimizing clashing with other python files, I propose to change the default cell marker from `##` to `#:`. The double comment is common in my existing python code, perhaps because I wanted to emphasize the comment, or because I commented a region that contained comments. What do you think?