### PR TITLE
Append ESC + ENTER at end of commands sent to IPython shell

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -105,6 +105,7 @@
     "Sanderson",
     "Sanderson's",
     "setuptools",
+    "trippy",
     "venv",
     "virtualenvs",
     "wglinfo",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -188,7 +188,7 @@ async function previewSelection() {
  */
 async function clearScene() {
   try {
-    await ManimShell.instance.executeCommandErrorOnNoActiveSession("clear()");
+    await ManimShell.instance.executeIPythonCommandExpectSession("clear()");
   } catch (error) {
     if (error instanceof NoActiveShellError) {
       Window.showWarningMessage("No active Manim session found to remove objects from.");

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -229,34 +229,34 @@ export class ManimShell {
   }
 
   /**
-   * Executes the given command. If no active terminal running Manim is found,
-   * a new terminal is spawned, and a new Manim session is started in it
-   * before executing the given command.
+   * Executes the given IPython command. If no active terminal running Manim
+   * is found, a new terminal is spawned, and a new Manim session is started
+   * in it beforehand.
    *
    * This command is locked during startup to prevent multiple new scenes from
    * being started at the same time, see `lockDuringStartup`.
    *
-   * For params explanations, see the docs for `execCommand()`.
+   * For params explanations, see the docs for `execIPythonCommand()`.
    */
-  public async executeCommand(
+  public async executeIPythonCommand(
     command: string, startLine: number, waitUntilFinished = false,
     handler?: CommandExecutionEventHandler,
   ) {
-    await this.execCommand(
+    await this.execIPythonCommand(
       command, waitUntilFinished, false, false, startLine, handler);
   }
 
   /**
-   * Executes the given command, but only if an active ManimGL shell exists.
-   * Otherwise throws a `NoActiveShellError`.
+   * Executes the given IPython command, but only if an active ManimGL shell
+   * exists. Otherwise throws a `NoActiveShellError`.
    *
-   * For params explanations, see the docs for `execCommand()`.
+   * For params explanations, see the docs for `execIPythonCommand()`.
    * @throws NoActiveShellError If no active shell is found.
    */
-  public async executeCommandErrorOnNoActiveSession(
+  public async executeIPythonCommandExpectSession(
     command: string, waitUntilFinished = false, forceExecute = false,
   ) {
-    await this.execCommand(
+    await this.execIPythonCommand(
       command, waitUntilFinished, forceExecute, true, undefined, undefined);
   }
 
@@ -264,7 +264,7 @@ export class ManimShell {
    * Returns whether the command execution is currently locked, i.e. when
    * Manim is starting up or another command is currently running.
    *
-   * @param forceExecute see `execCommand()`
+   * @param forceExecute see `execIPythonCommand()`
    * @returns true if the command execution is locked, false otherwise.
    */
   private async isLocked(forceExecute = false): Promise<boolean> {
@@ -291,7 +291,7 @@ export class ManimShell {
   }
 
   /**
-   * Executes a given command and bundles many different behaviors and options.
+   * Executes a given IPython command.
    *
    * This method is internal and only exposed via other public methods that
    * select a specific behavior.
@@ -318,7 +318,7 @@ export class ManimShell {
    * shell is required for the command execution (when `errorOnNoActiveShell`
    * is set to true).
    */
-  private async execCommand(
+  private async execIPythonCommand(
     command: string,
     waitUntilFinished: boolean,
     forceExecute: boolean,
@@ -326,6 +326,9 @@ export class ManimShell {
     startLine?: number,
     handler?: CommandExecutionEventHandler,
   ) {
+    // append ESC + ENTER to avoid IPython starting a multi-line input (#18)
+    command += "\x1b\x0d";
+
     Logger.debug(`🚀 Exec command: ${command}, waitUntilFinished=${waitUntilFinished}`
       + `, forceExecute=${forceExecute}, errorOnNoActiveShell=${errorOnNoActiveShell}`);
 

--- a/src/previewCode.ts
+++ b/src/previewCode.ts
@@ -81,7 +81,7 @@ export async function reloadAndPreviewManimCell(cellCode?: string, startLine?: n
   if (ManimShell.instance.hasActiveShell()) {
     const reloadCmd = `reload(${startLineParsed + 1})`;
     await ManimShell.instance.nextTimeWaitForRestartedIPythonInstance();
-    await ManimShell.instance.executeCommandErrorOnNoActiveSession(reloadCmd, true);
+    await ManimShell.instance.executeIPythonCommandExpectSession(reloadCmd, true);
   }
   await previewManimCell(cellCodeParsed, startLineParsed);
 }
@@ -111,7 +111,7 @@ export async function previewCode(code: string, startLine: number): Promise<void
     const clipboardBuffer = await vscode.env.clipboard.readText();
     await vscode.env.clipboard.writeText(code);
 
-    await ManimShell.instance.executeCommand(
+    await ManimShell.instance.executeIPythonCommand(
       PREVIEW_COMMAND, startLine, true, {
         onCommandIssued: (shellStillExists) => {
           Logger.debug(`📊 Command issued: ${PREVIEW_COMMAND}. Will restore clipboard`);


### PR DESCRIPTION
During testing in #109, we noticed that #18 is still not working on Windows machines, even with #81. I try to address the issue here again, with a solution inspired by [this SO answer](https://stackoverflow.com/a/54863672/9655481). I.e. we append `ESC + ENTER` to any command sent to an IPython shell, see the line:

```ts
// append ESC + ENTER to avoid IPython starting a multi-line input (#18)
command += "\x1b\x0d";
```

This seems to work in CI/CD based on [this run](https://github.com/Manim-Notebook/manim-notebook/actions/runs/12707022348/job/35421086858?pr=109) on #109 that already has the changes of this PR merged.

---

For reviewers on Windows machines @RickLuiken:
- please test that you can use the extension as usual, e.g. to preview cells.
- if this fix works: does it still work if you comment out [these lines](https://github.com/Manim-Notebook/manim-notebook/blob/10e92c3a22f4db8239164835ec6c81afc95cf9c1/src/manimShell.ts#L773-L779)?