### PR TITLE
Make ManimGL version detection more robust in Python venv

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -202,15 +202,15 @@ async function waitForPythonExtension(): Promise<string | undefined> {
 }
 
 /**
- * Transforms a path to either a environment folder or a Python executable
- * into a path to the ManimGL binary.
+ * Transforms a path pointing to either an environment folder or a
+ * Python executable into a path pointing to the ManimGL binary.
  *
- * @param path The path to the Python environment or executable.
+ * @param path The path to the Python environment or Python executable.
  * @returns The path to the ManimGL binary.
  */
 function pythonEnvToManimglPath(envPath: string): string {
-  if (envPath.endsWith("python")) {
-    return envPath.replace("python", "manimgl");
+  if (envPath.endsWith("python") || envPath.endsWith("python3")) {
+    return envPath.replace(/python3?$/, "manimgl");
   } else {
     return path.join(envPath, "bin", "manimgl");
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -212,7 +212,8 @@ function pythonEnvToManimglPath(envPath: string): string {
   if (envPath.endsWith("python") || envPath.endsWith("python3")) {
     return envPath.replace(/python3?$/, "manimgl");
   } else {
-    return path.join(envPath, "bin", "manimgl");
+    const binFolderName = process.platform === "win32" ? "Scripts" : "bin";
+    return path.join(envPath, binFolderName, "manimgl");
   }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,7 +45,8 @@ export async function activate(context: vscode.ExtensionContext) {
     manimglPath = await waitForPythonExtension();
   } catch (err) {
     if (err instanceof WaitingForPythonExtensionCancelled) {
-      Logger.info("💠 Waiting for Python extension cancelled, cancelling activation");
+      Logger.info("💠 Waiting for Python extension cancelled, therefore"
+        + " we cancel the extension activation");
       return;
     }
   }
@@ -179,23 +180,23 @@ async function waitForPythonExtension(): Promise<string | undefined> {
   return await window.withProgress(progressOptions, async (progress, token) => {
     token.onCancellationRequested(() => {
       Window.showInformationMessage("Manim Notebook activation cancelled."
-        + " Open any Python file to activate the extension again.");
+        + " Open any Python file to again activate the extension.");
       throw new WaitingForPythonExtensionCancelled();
     });
 
+    // Waiting for Python extension
     const pythonApi = await pythonExtension.activate();
     Logger.info("💠 Python extension activated");
 
+    // Path to venv
     const environmentPath = pythonApi.environments.getActiveEnvironmentPath();
     if (!environmentPath) {
       return;
     }
-
     const environment = await pythonApi.environments.resolveEnvironment(environmentPath);
     if (!environment) {
       return;
     }
-
     return environment.path;
   });
 }

--- a/src/manimVersion.ts
+++ b/src/manimVersion.ts
@@ -133,6 +133,9 @@ async function fetchLatestManimVersion(): Promise<string | undefined> {
 
 /**
  * Tries to determine the Manim version with the `manimgl --version` command.
+ *
+ * @param manimglPath The path to the ManimGL executable, e.g. in a virtual
+ * environment. If undefined, we assume that `manimgl` is in the PATH.
  */
 export async function tryToDetermineManimVersion(manimglPath: string | undefined = undefined) {
   MANIM_VERSION = undefined;


### PR DESCRIPTION
Users might install Manim inside a Python virtual environment (venv). The Microsoft Python extension will automatically source the venv activation script (e.g. `./venv/bin/activate`) for every new terminal that the user opens in VSCode.

However, when our extension loads, the Python extension might not be fully loaded, therefore our `manimgl --version` command will fail since `manimgl` could not be found. Therefore:

- If the user has the Python extension installed, we wait for it to be activated before continuing with our own activation.
- Yet, some features of the Python extension are only available after a few seconds, even though it signaled to us that it is finished activating itself. Therefore, we immediately query its API to find out about the user environment path. We then use that path to invoke `manimgl` in a new terminal (where the venv activation script was not yet executed).

This should make the overall startup experience of our extension a lot smoother for users that install Manim to a virtual Python environment (which is actually the recommended way to install any dependencies in Python).