### PR TITLE
Rework Manim Cell detection heuristic

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -51,6 +51,10 @@
   //////////////////////////////////////
   "editor.indentSize": 2,
   "editor.tabSize": 2,
+  "[python]": {
+    "editor.indentSize": 4,
+    "editor.tabSize": 4
+  },
   "editor.insertSpaces": true,
   "editor.detectIndentation": false,
   "editor.renderFinalNewline": "on",

--- a/src/export.ts
+++ b/src/export.ts
@@ -3,7 +3,7 @@ import { window, TextDocument, CancellationToken, CodeLens } from "vscode";
 import {
   MultiStepInput, toQuickPickItems, shouldResumeNoOp,
 } from "./utils/multiStepQuickPickUtil";
-import { findClassLines, findManimSceneName } from "./pythonParsing";
+import { findManimClasses, findManimSceneName } from "./pythonParsing";
 import { Logger, Window } from "./logger";
 import { waitNewTerminalDelay } from "./utils/terminal";
 
@@ -228,7 +228,7 @@ export class ExportSceneCodeLens implements vscode.CodeLensProvider {
   public provideCodeLenses(document: TextDocument, _token: CancellationToken): CodeLens[] {
     const codeLenses: vscode.CodeLens[] = [];
 
-    for (const classLine of findClassLines(document)) {
+    for (const classLine of findManimClasses(document)) {
       const range = new vscode.Range(classLine.lineNumber, 0, classLine.lineNumber, 0);
 
       codeLenses.push(new vscode.CodeLens(range, {

--- a/src/export.ts
+++ b/src/export.ts
@@ -59,7 +59,7 @@ export async function exportScene(sceneName?: string) {
     }
 
     const sceneClassLine = ManimClass
-      .findManimSceneName(editor.document, editor.selection.start.line);
+      .getManimClassAtCursor(editor.document, editor.selection.start.line);
     if (!sceneClassLine) {
       return Window.showErrorMessage("Place your cursor in a Manim scene.");
     }

--- a/src/export.ts
+++ b/src/export.ts
@@ -3,7 +3,7 @@ import { window, TextDocument, CancellationToken, CodeLens } from "vscode";
 import {
   MultiStepInput, toQuickPickItems, shouldResumeNoOp,
 } from "./utils/multiStepQuickPickUtil";
-import { findManimClasses, findManimSceneName } from "./pythonParsing";
+import { ManimClass } from "./pythonParsing";
 import { Logger, Window } from "./logger";
 import { waitNewTerminalDelay } from "./utils/terminal";
 
@@ -58,7 +58,8 @@ export async function exportScene(sceneName?: string) {
         "No opened file found. Please place your cursor in a Manim scene.");
     }
 
-    const sceneClassLine = findManimSceneName(editor.document, editor.selection.start.line);
+    const sceneClassLine = ManimClass
+      .findManimSceneName(editor.document, editor.selection.start.line);
     if (!sceneClassLine) {
       return Window.showErrorMessage("Place your cursor in a Manim scene.");
     }
@@ -228,7 +229,7 @@ export class ExportSceneCodeLens implements vscode.CodeLensProvider {
   public provideCodeLenses(document: TextDocument, _token: CancellationToken): CodeLens[] {
     const codeLenses: vscode.CodeLens[] = [];
 
-    for (const classLine of findManimClasses(document)) {
+    for (const classLine of ManimClass.findAllIn(document)) {
       const range = new vscode.Range(classLine.lineNumber, 0, classLine.lineNumber, 0);
 
       codeLenses.push(new vscode.CodeLens(range, {

--- a/src/pythonParsing.ts
+++ b/src/pythonParsing.ts
@@ -154,7 +154,7 @@ export class ManimClass {
   /**
    * Regular expression to match the construct() method definition.
    */
-  private static CONSTRUCT__METHOD_REGEX = /^\s*def\s+construct\s*\(self\)\s*:/;
+  private static CONSTRUCT_METHOD_REGEX = /^\s*def\s+construct\s*\(self\)\s*:/;
 
   line: string;
   lineNumber: number; // 0-based
@@ -203,7 +203,7 @@ export class ManimClass {
         continue;
       }
 
-      if (line.match(this.CONSTRUCT__METHOD_REGEX) && candidate) {
+      if (line.match(this.CONSTRUCT_METHOD_REGEX) && candidate) {
         candidate.constructMethod = this.makeConstructMethodInfo(lines, lineNumber);
         candidate = null;
       }

--- a/src/pythonParsing.ts
+++ b/src/pythonParsing.ts
@@ -1,6 +1,5 @@
 import * as crypto from "crypto";
-import * as vscode from "vscode";
-import { TextDocument } from "vscode";
+import { TextDocument, Range } from "vscode";
 import { Logger } from "./logger";
 
 class Cache<T> {
@@ -30,7 +29,7 @@ class Cache<T> {
   }
 }
 
-const cellRangesCache = new Cache<vscode.Range[]>();
+const cellRangesCache = new Cache<Range[]>();
 const manimClassesCache = new Cache<ManimClass[]>();
 
 /**
@@ -64,13 +63,13 @@ export class ManimCellRanges {
    * Manim Cells are only recognized inside the construct() method of a
    * Manim class (see `ManimClass`).
    */
-  public static calculateRanges(document: vscode.TextDocument): vscode.Range[] {
+  public static calculateRanges(document: TextDocument): Range[] {
     const cachedRanges = cellRangesCache.get(document);
     if (cachedRanges) {
       return cachedRanges;
     }
 
-    const ranges: vscode.Range[] = [];
+    const ranges: Range[] = [];
     const manimClasses = ManimClass.findAllIn(document);
 
     manimClasses.forEach((manimClass) => {
@@ -123,7 +122,7 @@ export class ManimCellRanges {
    * Returns null if no cell range contains the line, e.g. if the cursor is
    * outside of a Manim cell.
    */
-  public static getCellRangeAtLine(document: TextDocument, line: number): vscode.Range | null {
+  public static getCellRangeAtLine(document: TextDocument, line: number): Range | null {
     const ranges = ManimCellRanges.calculateRanges(document);
     for (const range of ranges) {
       if (range.start.line <= line && line <= range.end.line) {
@@ -137,14 +136,12 @@ export class ManimCellRanges {
    * Constructs a new cell range from the given start and end line numbers.
    * Discards all trailing empty lines at the end of the range.
    */
-  private static constructRange(
-    document: vscode.TextDocument, start: number, end: number,
-  ): vscode.Range {
+  private static constructRange(document: TextDocument, start: number, end: number): Range {
     let endNew = end;
     while (endNew > start && document.lineAt(endNew).isEmptyOrWhitespace) {
       endNew--;
     }
-    return new vscode.Range(start, 0, endNew, document.lineAt(endNew).text.length);
+    return new Range(start, 0, endNew, document.lineAt(endNew).text.length);
   }
 }
 
@@ -213,7 +210,7 @@ export class ManimClass {
    *
    * @param document The document to search in.
    */
-  public static findAllIn(document: vscode.TextDocument): ManimClass[] {
+  public static findAllIn(document: TextDocument): ManimClass[] {
     const cachedClasses = manimClassesCache.get(document);
     if (cachedClasses) {
       return cachedClasses;

--- a/src/pythonParsing.ts
+++ b/src/pythonParsing.ts
@@ -208,7 +208,7 @@ function findClasses(document: vscode.TextDocument): ClassLine[] {
  * Returns the lines that define Manim classes in the given document.
  *
  * A Manim class is defined as:
- * - Inherits from any object. Not necessarily "Scene" since users might want
+ * - Inherits from any object. Not necessarily "Scene" since users might want to
  *   use inheritance where just the base class inherits from "Scene".
  * - Contains a "def construct(self)" method with exactly this signature.
  *

--- a/src/pythonParsing.ts
+++ b/src/pythonParsing.ts
@@ -10,7 +10,7 @@ import { TextDocument, Range } from "vscode";
  */
 class Cache<T> {
   private cache: Map<string, T> = new Map();
-  private static readonly MAX_CACHE_SIZE = 5;
+  private static readonly MAX_CACHE_SIZE = 100;
 
   private hash(document: TextDocument): string {
     const text = document.getText();

--- a/src/pythonParsing.ts
+++ b/src/pythonParsing.ts
@@ -6,6 +6,7 @@ import { Logger } from "./logger";
 class Cache {
   public cellRanges: Map<string, vscode.Range[]> = new Map();
   public manimClasses: Map<string, ManimClass[]> = new Map();
+  private static readonly MAX_CACHE_SIZE = 5;
 
   private hash(document: vscode.TextDocument): string {
     const text = document.getText();
@@ -23,6 +24,15 @@ class Cache {
   }
 
   public addCellRanges(document: vscode.TextDocument, ranges: vscode.Range[]): void {
+    if (this.cellRanges.size >= Cache.MAX_CACHE_SIZE) {
+      const keys = this.cellRanges.keys();
+      const firstKey = keys.next().value;
+      if (firstKey) {
+        console.log("Cache DEL: Cell Ranges");
+        this.cellRanges.delete(firstKey);
+      }
+    }
+
     this.cellRanges.set(this.hash(document), ranges);
   }
 
@@ -36,6 +46,15 @@ class Cache {
   }
 
   public addManimClasses(document: vscode.TextDocument, classes: ManimClass[]): void {
+    if (this.manimClasses.size >= Cache.MAX_CACHE_SIZE) {
+      const keys = this.manimClasses.keys();
+      const firstKey = keys.next().value;
+      if (firstKey) {
+        console.log("Cache DEL: Manim Classes");
+        this.manimClasses.delete(firstKey);
+      }
+    }
+
     this.manimClasses.set(this.hash(document), classes);
   }
 }

--- a/src/pythonParsing.ts
+++ b/src/pythonParsing.ts
@@ -1,6 +1,5 @@
 import * as crypto from "crypto";
 import { TextDocument, Range } from "vscode";
-import { Logger } from "./logger";
 
 /**
  * Cache is a simple key-value store that keeps a maximum number of entries.

--- a/src/pythonParsing.ts
+++ b/src/pythonParsing.ts
@@ -224,12 +224,9 @@ export class ManimClass {
     for (let lineNumber = 0; lineNumber < lines.length; lineNumber++) {
       const line = lines[lineNumber];
 
-      const inheritedClassMatch = line.match(this.INHERITED_CLASS_REGEX);
-      if (inheritedClassMatch) {
-        candidate = new ManimClass(
-          line, lineNumber,
-          inheritedClassMatch[1], line.search(/\S/),
-        );
+      const match = line.match(this.INHERITED_CLASS_REGEX);
+      if (match) {
+        candidate = new ManimClass(line, lineNumber, match[1], line.search(/\S/));
         classes.push(candidate);
         continue;
       }

--- a/src/pythonParsing.ts
+++ b/src/pythonParsing.ts
@@ -203,9 +203,7 @@ export class ManimClass {
   classIndent: number;
   constructMethod: MethodInfo | null = null;
 
-  constructor(
-    line: string, lineNumber: number, className: string, classIndent: number,
-  ) {
+  constructor(line: string, lineNumber: number, className: string, classIndent: number) {
     this.line = line;
     this.lineNumber = lineNumber;
     this.className = className;

--- a/src/pythonParsing.ts
+++ b/src/pythonParsing.ts
@@ -40,7 +40,6 @@ export class ManimCellRanges {
 
     manimClasses.forEach((manimClass) => {
       const construct = manimClass.constructMethod;
-
       if (construct === null) {
         Logger.trace(`Manim class without construct() method: ${manimClass.className}`);
         return;
@@ -64,14 +63,16 @@ export class ManimCellRanges {
           inManimCell = true;
           start = i;
           end = i;
-        } else {
-          if (!inManimCell) {
-            start = i;
-          }
-          end = i;
+          continue;
         }
+
+        if (!inManimCell) {
+          start = i;
+        }
+        end = i;
       }
 
+      // last cell
       if (inManimCell) {
         ranges.push(ManimCellRanges.getRangeDiscardEmpty(document, start, endCell));
       }

--- a/src/pythonParsing.ts
+++ b/src/pythonParsing.ts
@@ -1,5 +1,4 @@
 import * as vscode from "vscode";
-import { Range } from "vscode";
 import { TextDocument } from "vscode";
 import { Logger } from "./logger";
 
@@ -56,9 +55,9 @@ export class ManimCellRanges {
         const line = document.lineAt(i);
         const indentation = line.firstNonWhitespaceCharacterIndex;
 
-        if (indentation === construct.bodyIndent && ManimCellRanges.MARKER.test(line.text)) {
+        if (indentation === construct.bodyIndent && this.MARKER.test(line.text)) {
           if (inManimCell) {
-            ranges.push(ManimCellRanges.getRangeDiscardEmpty(document, start, end));
+            ranges.push(this.constructRange(document, start, end));
           }
           inManimCell = true;
           start = i;
@@ -74,7 +73,7 @@ export class ManimCellRanges {
 
       // last cell
       if (inManimCell) {
-        ranges.push(ManimCellRanges.getRangeDiscardEmpty(document, start, endCell));
+        ranges.push(this.constructRange(document, start, endCell));
       }
     });
 
@@ -101,7 +100,7 @@ export class ManimCellRanges {
    * Constructs a new cell range from the given start and end line numbers.
    * Discards all trailing empty lines at the end of the range.
    */
-  private static getRangeDiscardEmpty(
+  private static constructRange(
     document: vscode.TextDocument, start: number, end: number,
   ): vscode.Range {
     let endNew = end;

--- a/src/pythonParsing.ts
+++ b/src/pythonParsing.ts
@@ -2,6 +2,13 @@ import * as crypto from "crypto";
 import { TextDocument, Range } from "vscode";
 import { Logger } from "./logger";
 
+/**
+ * Cache is a simple key-value store that keeps a maximum number of entries.
+ * The key is a VSCode TextDocument, and the value is of the generic type T.
+ *
+ * The cache is used to store the results of expensive calculations, e.g. the
+ * Manim cell ranges in a document.
+ */
 class Cache<T> {
   private cache: Map<string, T> = new Map();
   private static readonly MAX_CACHE_SIZE = 5;

--- a/src/startStopScene.ts
+++ b/src/startStopScene.ts
@@ -43,7 +43,7 @@ export async function startScene(lineStart?: number) {
 
   const lines = editor.document.getText().split("\n");
   let cursorLine = lineStart || editor.selection.start.line;
-  const sceneClassLine = ManimClass.findManimSceneName(editor.document, cursorLine);
+  const sceneClassLine = ManimClass.getManimClassAtCursor(editor.document, cursorLine);
   if (!sceneClassLine) {
     Window.showErrorMessage("Place your cursor in Manim code inside a class.");
     return;

--- a/src/startStopScene.ts
+++ b/src/startStopScene.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { ManimShell, NoActiveShellError } from "./manimShell";
 import { window, workspace } from "vscode";
 import { Logger, Window } from "./logger";
-import { findManimSceneName } from "./pythonParsing";
+import { ManimClass } from "./pythonParsing";
 import { isAtLeastManimVersion } from "./manimVersion";
 
 /**
@@ -43,7 +43,7 @@ export async function startScene(lineStart?: number) {
 
   const lines = editor.document.getText().split("\n");
   let cursorLine = lineStart || editor.selection.start.line;
-  const sceneClassLine = findManimSceneName(editor.document, cursorLine);
+  const sceneClassLine = ManimClass.findManimSceneName(editor.document, cursorLine);
   if (!sceneClassLine) {
     Window.showErrorMessage("Place your cursor in Manim code inside a class.");
     return;

--- a/tests/cellRanges.test.ts
+++ b/tests/cellRanges.test.ts
@@ -1,0 +1,64 @@
+import { workspace, Range } from "vscode";
+import { describe, it } from "mocha";
+import { uriInWorkspace } from "./utils/testRunner";
+import { ManimCellRanges } from "../src/pythonParsing";
+
+describe("Manim Cell Ranges", function () {
+  // in the expected ranges we only care about the start and end lines
+  // line numbers are 0-based here
+  const tests = [
+    {
+      filename: "detection_basic.py",
+      expectedRanges: [[5, 7], [9, 10]],
+    },
+    {
+      filename: "detection_class_definition.py",
+      expectedRanges: [[9, 11], [13, 14]],
+    },
+    {
+      filename: "detection_inside_construct.py",
+      expectedRanges: [[5, 12], [14, 16]],
+    },
+    {
+      filename: "detection_multiple_inheritance.py",
+      expectedRanges: [[5, 7], [9, 21], [14, 21], [31, 33], [35, 36]],
+    },
+    {
+      filename: "detection_multiple_methods.py",
+      expectedRanges: [[5, 7], [9, 10]],
+    },
+    {
+      filename: "detection_syntax.py",
+      expectedRanges: [[5, 9], [11, 12], [14, 15], [17, 17], [19, 19],
+        [25, 25], [31, 32], [33, 34], [35, 35], [36, 36]],
+    },
+  ];
+
+  tests.forEach(function (test) {
+    it(`Correctly assigns ranges for ${test.filename}`, async () => {
+      const uri = uriInWorkspace(test.filename);
+      const document = await workspace.openTextDocument(uri);
+
+      const ranges: Range[] = ManimCellRanges.calculateRanges(document);
+      const expectedRanges = test.expectedRanges;
+
+      if (ranges.length !== expectedRanges.length) {
+        throw new Error(`Expected ${expectedRanges.length} ranges, but got ${ranges.length}`);
+      }
+
+      for (let i = 0; i < ranges.length; i++) {
+        const range = ranges[i];
+        const expectedRange = expectedRanges[i];
+
+        if (range.start.line !== expectedRange[0]) {
+          throw new Error(`Start line does not match (${i}):`
+            + ` expected: ${expectedRange[0]}, actual: ${range.start.line}`);
+        }
+        if (range.end.line !== expectedRange[1]) {
+          throw new Error(`End line does not match (${i}):`
+            + ` expected: ${expectedRange[1]}, actual: ${range.end.line}`);
+        }
+      }
+    });
+  });
+});

--- a/tests/fixtures/detection_basic.py
+++ b/tests/fixtures/detection_basic.py
@@ -1,0 +1,17 @@
+from manimlib import *
+
+
+class BasicNotebook(Scene):
+    def construct(self):
+        ## A Manim Cell
+        print("With some code")
+        print("With some more code")
+
+        ## And another Manim Cell
+        print("And even more code")
+
+
+class NoManimScene(Scene):
+    def constructtttt(self):
+        ## Should not be detected as Manim Cell
+        print("Hi there")

--- a/tests/fixtures/detection_basic.py
+++ b/tests/fixtures/detection_basic.py
@@ -15,3 +15,9 @@ class NoManimScene(Scene):
     def constructtttt(self):
         ## Should not be detected as Manim Cell
         print("Hi there")
+
+
+class WithoutAnyManimCells(Scene):
+    def construct(self):
+        print("We have no ManimCell in here")
+        print("And therefore also no ManimCell is detected")

--- a/tests/fixtures/detection_class_definition.py
+++ b/tests/fixtures/detection_class_definition.py
@@ -1,0 +1,35 @@
+from manimlib import *
+
+
+class AnythingElse:
+    pass
+
+
+class Inheritance(AnythingElse):
+    def construct(self):
+        ## A Manim Cell
+        print("With some code")
+        print("With some more code")
+
+        ## And another Manim Cell
+        print("And even more code")
+
+
+class InheritanceNothing():  # don't remove "()" here (!)
+    def construct(self):
+        ## Should not be detected as Manim Cell
+        print("With some code")
+        print("With some more code")
+
+        ## Should neither be detected as Manim Cell
+        print("And even more code")
+
+
+class InheritanceNothingWithoutParentheses:
+    def construct(self):
+        ## Should not be detected as Manim Cell
+        print("With some code")
+        print("With some more code")
+
+        ## Should neither be detected as Manim Cell
+        print("And even more code")

--- a/tests/fixtures/detection_inside_construct.py
+++ b/tests/fixtures/detection_inside_construct.py
@@ -5,7 +5,7 @@ class SceneDetectionInsideConstruct(Scene):
     def construct(self):
         ## A Manim Cell
         def some_function():
-            ## Not a Manim Cell
+            ## Not a Manim Cell, instead part of the outer one
             print("Not a Manim Cell")
 
         print("With some code")

--- a/tests/fixtures/detection_inside_construct.py
+++ b/tests/fixtures/detection_inside_construct.py
@@ -1,0 +1,17 @@
+from manimlib import *
+
+
+class SceneDetectionInsideConstruct(Scene):
+    def construct(self):
+        ## A Manim Cell
+        def some_function():
+            ## Not a Manim Cell
+            print("Not a Manim Cell")
+
+        print("With some code")
+        some_function()
+        print("With some more code")
+
+        ## And another Manim Cell
+        print("And even more code")
+        some_function()

--- a/tests/fixtures/detection_multiple_inheritance.py
+++ b/tests/fixtures/detection_multiple_inheritance.py
@@ -1,0 +1,37 @@
+from manimlib import *
+
+
+class BasicNotebook(Scene):
+    def construct(self):
+        ## A Manim Cell
+        print("With some code")
+        print("With some more code")
+
+        ## And another Manim Cell
+        print("And even more code")
+
+        class AnInvalidManimScene(Scene):
+            def construct(self):
+                ## Not a Manim Cell, but still detected as one
+                # We mark this as undefined behavior and Manim does not support
+                # a scene inside another scene.
+                # We still consider this as a Manim Cell since detecting this
+                # case would be too cumbersome to be worth it to consider.
+                # The user will find out in Manim itself that this is not
+                # supported.
+                print("Not a valid Manim Scene")
+
+
+class BaseClass(Scene):
+    def setup(self):
+        print("Setting up")
+
+
+class SubClass(BaseClass):
+    def construct(self):
+        ## A Manim Cell in a subclass
+        print("Constructing")
+        print("Hey there")
+
+        ## Another Manim Cell in a subclass
+        print("Constructing more")

--- a/tests/fixtures/detection_multiple_methods.py
+++ b/tests/fixtures/detection_multiple_methods.py
@@ -1,0 +1,15 @@
+from manimlib import *
+
+
+class MultipleMethods(Scene):
+    def construct(self):
+        ## A Manim Cell
+        print("With some code")
+        print("With some more code")
+
+        ## And another Manim Cell
+        print("And even more code")
+
+    def another_construct(self):
+        ## Should not be detected as Manim Cell
+        print("Hi there from another construct method")

--- a/tests/fixtures/detection_syntax.py
+++ b/tests/fixtures/detection_syntax.py
@@ -3,14 +3,14 @@ from manimlib import *
 
 class Syntax(Scene):
     def construct(self):
-        ## A Manim Scene
+        ## A Manim Cell
         print("Hello, Manim!")
 
-        # Not a Manim Scene, just a regular comment
-        print("Not a Manim Scene")
+        # Not a Manim Cell, just a regular comment
+        print("Not a Manim Cell")
 
-        ### A Manim Scene
+        ### A Manim Cell
         print("Hello, Manim!")
 
-        ########## # # # # A Manim Scene
+        ########## # # # # A Manim Cell
         print("Hello, Manim!")

--- a/tests/fixtures/detection_syntax.py
+++ b/tests/fixtures/detection_syntax.py
@@ -18,3 +18,20 @@ class Syntax(Scene):
         ## A Manim Cell without any code
 
         ## Another empty Manim Cell
+
+
+class SyntaxNotAtStart(Scene):
+    def construct(self):
+        print("test")
+        ## Empty Manim Cell, should start here, not at the line before
+
+
+class WithoutNewLine(Scene):
+    def construct(self):
+        print("test")
+        ## First ManimCell
+        print("yeah")
+        ## Second ManimCell
+        print("yeah2")
+        ## Third ManimCell
+        ## Fourth ManimCell

--- a/tests/fixtures/detection_syntax.py
+++ b/tests/fixtures/detection_syntax.py
@@ -1,0 +1,16 @@
+from manimlib import *
+
+
+class Syntax(Scene):
+    def construct(self):
+        ## A Manim Scene
+        print("Hello, Manim!")
+
+        # Not a Manim Scene, just a regular comment
+        print("Not a Manim Scene")
+
+        ### A Manim Scene
+        print("Hello, Manim!")
+
+        ########## # # # # A Manim Scene
+        print("Hello, Manim!")

--- a/tests/fixtures/detection_syntax.py
+++ b/tests/fixtures/detection_syntax.py
@@ -14,3 +14,7 @@ class Syntax(Scene):
 
         ########## # # # # A Manim Cell
         print("Hello, Manim!")
+
+        ## A Manim Cell without any code
+
+        ## Another empty Manim Cell


### PR DESCRIPTION
Closes #12 by adapting [this heuristic](https://github.com/Manim-Notebook/manim-notebook/issues/12#issuecomment-2442317826). I.e. we improve the detection of when we are in an actual file which is to be interpreted by Manim.

Note however that I did not implement the first point of my mentioned heuristic. Instead, we only show Manim Cells in the `construct()` method and in no other method. I don't see any reason why one would want a Manim Cell inside another method and browsing through some [3b1b video code](https://github.com/3b1b/videos) from 2024 I did not find any use case either. If there is one, please let me know. Otherwise, users will open an issue for us ;)

Furthermore, note how a Manim class is now defined:

```ts
/**
 * A Manim class is defined as:
 *
 * - Inherits from any object. This constraint is necessary since in the chain
 *   of class inheritance, the base class must inherit from "Scene", otherwise
 *   Manim itself won't recognize the class as a scene. We don't enforce the
 *   name "Scene" here since subclasses might also inherit from other classes.
 *
 * - Contains a "def construct(self)" method with exactly this signature.
 *
 * This class provides static methods to work with Manim classes in a
 * Python document.
 */
export class ManimClass { ... }
```

---

I've added some tests for the cell ranges to cover "usual cases" as well as edge cases. This is also a good opportunity for reviewers to try out the new testing setup locally. See the [developing guide](https://github.com/Manim-Notebook/manim-notebook/wiki/Developing).

TODO:
- [x] Refactor `pythonParsing` and update docstring for `calculateRanges()`
- [x] Add a caching mechanism such that intensive calculations don't have to be performed multiple times.