### PR TITLE
Use NodeJS Filesystem API to create directories

### DIFF
--- a/tests/utils/manimInstaller.ts
+++ b/tests/utils/manimInstaller.ts
@@ -1,5 +1,5 @@
 import { exec } from "child_process";
-import { existsSync } from "fs";
+import { existsSync, mkdirSync } from "fs";
 import * as path from "path";
 
 function run(cmd: string, ...args: any): Promise<any> {
@@ -65,7 +65,10 @@ export class ManimInstaller {
 
     // Manim installation path
     this.manimPath = path.join(tmpFolder, "manim");
-    await run(`mkdir -p ${this.manimPath}`);
+    if (!existsSync(this.manimPath)) {
+      mkdirSync(this.manimPath, { recursive: true });
+    }
+
     console.log(`🍭 Manim installation path: ${this.manimPath}`);
 
     // Python virtual environment path


### PR DESCRIPTION
Always use NodeJS' API to check and create directories. Because running any command like `mkdir` starts a new process every time. Also `mkdir -p` is different on Windows and Linux. `mkdir -p` on Windows creates a directory names `-p`. This difference in utilities across platforms goes for many filesystem-related utils.