### PR TITLE
Rework ManimGL version detection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -112,6 +112,7 @@
     "pycache",
     "Pyglet",
     "pyperclip",
+    "Redetects",
     "Sanderson",
     "Sanderson's",
     "setuptools",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,11 +46,10 @@ export async function activate(context: vscode.ExtensionContext) {
       // (These tasks here can be performed in the background)
 
       // also see https://github.com/Manim-Notebook/manim-notebook/pull/117#discussion_r1932764875
-      const pythonBinInVenv = process.platform === "win32" ? "python.exe" : "python3";
-      const pythonBinOutsideVenv = process.platform === "win32" ? "python" : "python3";
+      const pythonBin = process.platform === "win32" ? "python" : "python3";
       pythonBinary = pythonEnvPath
-        ? getBinaryPathInPythonEnv(pythonEnvPath, pythonBinInVenv)
-        : pythonBinOutsideVenv;
+        ? getBinaryPathInPythonEnv(pythonEnvPath, pythonBin)
+        : pythonBin;
 
       if (process.platform === "win32") {
         applyWindowsPastePatch(context, pythonBinary);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,7 +59,7 @@ export async function activate(context: vscode.ExtensionContext) {
     });
   } catch (err) {
     Logger.error("Error in background activation processing"
-      + ` (python extension waiting, windows paste patch, manim version check): ${err}`);
+      + ` (python extension waiting, windows paste patch or manim version check): ${err}`);
   }
 
   const previewManimCellCommand = vscode.commands.registerCommand(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,6 +40,7 @@ export async function activate(context: vscode.ExtensionContext) {
     });
   context.subscriptions.push(openWalkthroughCommand);
 
+  let pythonBinary: string;
   try {
     waitForPythonExtension().then((pythonEnvPath: string | undefined) => {
       // (These tasks here can be performed in the background)
@@ -47,7 +48,7 @@ export async function activate(context: vscode.ExtensionContext) {
       // also see https://github.com/Manim-Notebook/manim-notebook/pull/117#discussion_r1932764875
       const pythonBinInVenv = process.platform === "win32" ? "python.exe" : "python3";
       const pythonBinOutsideVenv = process.platform === "win32" ? "python" : "python3";
-      const pythonBinary = pythonEnvPath
+      pythonBinary = pythonEnvPath
         ? getBinaryPathInPythonEnv(pythonEnvPath, pythonBinInVenv)
         : pythonBinOutsideVenv;
 
@@ -128,9 +129,13 @@ export async function activate(context: vscode.ExtensionContext) {
     });
 
   const redetectManimVersionCommand = vscode.commands.registerCommand(
-    "manim-notebook.redetectManimVersion", () => {
+    "manim-notebook.redetectManimVersion", async () => {
       Logger.info("💠 Command requested: Redetect Manim Version");
-      determineManimVersion("manimgl");
+      if (!pythonBinary) {
+        Window.showWarningMessage("Please wait for Manim Notebook to have finished activating.");
+        return;
+      }
+      await determineManimVersion(pythonBinary);
     });
 
   registerWalkthroughCommands(context);

--- a/src/manimVersion.ts
+++ b/src/manimVersion.ts
@@ -171,10 +171,10 @@ export async function determineManimVersion(pythonBinary: string | undefined) {
 
   if (couldDetermineManimVersion) {
     Logger.info(`👋 ManimGL version found: ${MANIM_VERSION}`);
-    showPositiveUserVersionFeedback();
+    await showPositiveUserVersionFeedback();
   } else {
     Logger.info("👋 ManimGL version could not be determined");
-    showNegativeUserVersionFeedback();
+    await showNegativeUserVersionFeedback();
   }
 }
 

--- a/src/manimVersion.ts
+++ b/src/manimVersion.ts
@@ -171,10 +171,10 @@ export async function determineManimVersion(pythonBinary: string | undefined) {
 
   if (couldDetermineManimVersion) {
     Logger.info(`👋 ManimGL version found: ${MANIM_VERSION}`);
-    await showPositiveUserVersionFeedback();
+    showPositiveUserVersionFeedback();
   } else {
     Logger.info("👋 ManimGL version could not be determined");
-    await showNegativeUserVersionFeedback();
+    showNegativeUserVersionFeedback();
   }
 }
 
@@ -202,13 +202,18 @@ async function showPositiveUserVersionFeedback() {
   }
 }
 
-async function showNegativeUserVersionFeedback() {
-  const tryAgainAnswer = "Try again";
+function showNegativeUserVersionFeedback() {
+  const tryAgainOption = "Try again";
+  const openWalkthroughOption = "Open Walkthrough";
   const warningMessage = "Your ManimGL version could not be determined.";
-  const answer = await Window.showWarningMessage(warningMessage, tryAgainAnswer);
-  if (answer === tryAgainAnswer) {
-    await determineManimVersion(lastPythonBinary);
-  }
+  Window.showWarningMessage(warningMessage, tryAgainOption, openWalkthroughOption)
+    .then((selected) => {
+      if (selected === tryAgainOption) {
+        determineManimVersion(lastPythonBinary);
+      } else if (selected === openWalkthroughOption) {
+        vscode.commands.executeCommand("manim-notebook.openWalkthrough");
+      }
+    });
 }
 
 /**

--- a/src/manimVersion.ts
+++ b/src/manimVersion.ts
@@ -9,9 +9,22 @@ import * as vscode from "vscode";
  */
 let MANIM_VERSION: string | undefined;
 
+/**
+ * The last Python binary path that was used to determine the Manim version.
+ *
+ * This is used to retry the version determination if it failed the first time.
+ */
 let lastPythonBinary: string | undefined;
 
+/**
+ * The URL to the Manim releases page.
+ */
 const MANIM_RELEASES_URL = "https://github.com/3b1b/manim/releases";
+
+/**
+ * The URL to the API endpoint showing information about the latest
+ * Manim release.
+ */
 const MANIM_LATEST_RELEASE_API_URL = "https://api.github.com/repos/3b1b/manim/releases/latest";
 
 /**

--- a/src/previewCode.ts
+++ b/src/previewCode.ts
@@ -4,7 +4,7 @@ import { ManimShell } from "./manimShell";
 import { EventEmitter } from "events";
 import { ManimCellRanges } from "./pythonParsing";
 import { Logger, Window } from "./logger";
-import { hasUserMinimalManimVersion } from "./manimVersion";
+import { hasUserMinimalManimVersionAndWarn } from "./manimVersion";
 
 // \x0C: is Ctrl + L, which clears the terminal screen
 const PREVIEW_COMMAND = "\x0Ccheckpoint_paste()";
@@ -68,7 +68,7 @@ export async function previewManimCell(cellCode?: string, startLine?: number) {
 }
 
 export async function reloadAndPreviewManimCell(cellCode?: string, startLine?: number) {
-  if (!await hasUserMinimalManimVersion("1.7.2")) {
+  if (!await hasUserMinimalManimVersionAndWarn("1.7.2")) {
     return;
   }
 

--- a/src/startStopScene.ts
+++ b/src/startStopScene.ts
@@ -3,7 +3,7 @@ import { ManimShell, NoActiveShellError } from "./manimShell";
 import { window, workspace } from "vscode";
 import { Logger, Window } from "./logger";
 import { ManimClass } from "./pythonParsing";
-import { isAtLeastManimVersion } from "./manimVersion";
+import { hasUserMinimalManimVersion } from "./manimVersion";
 
 /**
  * Runs the `manimgl` command in the terminal, with the current cursor's
@@ -67,7 +67,7 @@ export async function startScene(lineStart?: number) {
   }
 
   // Autoreload
-  if (await isAtLeastManimVersion("1.7.2")) {
+  if (hasUserMinimalManimVersion("1.7.2")) {
     const autoreload = await workspace.getConfiguration("manim-notebook").get("autoreload");
     if (autoreload) {
       cmds.push("--autoreload");

--- a/tests/activation.test.ts
+++ b/tests/activation.test.ts
@@ -26,7 +26,7 @@ describe("Manim Activation", function () {
     sinon.restore();
   });
 
-  it("Can read from terminal", async () => {
+  it("Reads `manimgl --version` from terminal", async () => {
     console.log("Creating terminal");
     const terminal = window.createTerminal("Dummy terminal");
     terminal.show();
@@ -42,8 +42,8 @@ describe("Manim Activation", function () {
     });
   });
 
-  it("Detects Manim version", async () => {
-    // TODO: Test different Manim versions installed
+  it("Redetects Manim version", async () => {
+  // TODO: Test different Manim versions installed
     const spy = sinon.spy(window, "showInformationMessage");
     await commands.executeCommand("manim-notebook.redetectManimVersion");
     sinon.assert.called(spy);

--- a/tests/utils/testRunner.ts
+++ b/tests/utils/testRunner.ts
@@ -19,7 +19,7 @@ import { globSync } from "glob";
 import "source-map-support/register";
 import "./prototype";
 
-import { window, workspace, Uri } from "vscode";
+import { window, workspace, Uri, extensions } from "vscode";
 
 const WORKSPACE_ROOT: string = workspace.workspaceFolders![0].uri.fsPath;
 
@@ -70,9 +70,14 @@ export function run(): Promise<void> {
       // open any python file to trigger extension activation
       await window.showTextDocument(uriInWorkspace("basic.py"));
 
-      console.log("💠 Waiting for extension activation...");
-      await waitUntilExtensionActivated();
-      console.log("💠 Extension activation detected in tests");
+      const extension = await extensions.getExtension("manim-notebook.manim-notebook");
+      if (extension?.isActive) {
+        console.log("💠 Extension is detected as *activated*");
+      } else {
+        console.log("💠 Waiting for extension activation...");
+        await waitUntilExtensionActivated();
+        console.log("💠 Extension activation detected in tests");
+      }
 
       console.log("Running tests...");
       mocha.run((failures: any) => {


### PR DESCRIPTION
Closes #119.

### Manim Version detection

The previous approach of how to detect the user's Manim version was brittle and very slow since we directly called `manimgl --version` and also spawned a separate VSCode Terminal. Instead, we now use the `child_process.exec()` function from Node.js directly and execute the following command in the background:

```bash
<pythonBinary> -c "from importlib.metadata import version; print(version('manimgl'))"
```

From some [manual timing-tests](https://github.com/Manim-Notebook/manim-notebook/issues/119#issuecomment-2624637550), we see that this only takes less than 80ms compared to 1.8s of `manimgl --version` (of course on my machine and only a few runs).


### Why do we need the ManimGL version?

We need it to decide on several things, e.g.
- Are we able to call `manimgl` with the new `--autoreload` CLI flag? If the user has an older version of ManimGL installed, we don't want to include `--autoreload`, since then ManimGL would not even start correctly and complain about the unknown flag.
- Is the new `reload()` command available inside the IPython shell? Admittedly, for this, we could also send this Python command instead: `print("For this functionality, ManimGL vX.X.X is required.") if 'reload' not in globals() else reload()`. However, with our detection logic we have the possibility to better integrate into the VSCode framework, i.e. show an information message with a button to let the user try determining the version again or even opening our walkthrough containing an installation guide.
- (We will probably need this for other upcoming features of the extension that rely on some new Manim functionality.)

More benefits:
- If users don't have the latest version installed, they will be notified. This is especially useful if you're working with multiple Manim installations locally. By being informed about the version used, you can avoid errors where the user thinks that a specific Manim installation is used (while in reality it's another one).


### Known limitations

- Won't detect any other version strings than those in the format "1.2.3". Should 3Blue1Brown decide that they start with _release candidates_ and the like, we need to adapt the logic a bit to determine what a "newer" version is.
- Calls to the Manim Notebook extension are now non-blocking, i.e. other extension commands can already register, while we determine the version in the background. But you might still think that it takes quite some time for the extension to activate. This is due to:
   - VSCode activating the extension on our defined activation events (have a Python file open). And even if you have such a file open, VSCode might activate other extensions first. We have no control over the order of extension activation.
   - Before the Manim version is detected and the Windows paste patch applied, we still have to wait for the Python extension to be fully loaded (in the background). This is such that we can adapt the paths should the user be in a virtual environment (something that the Python extension will tell us after it has started up).
- Also note that we won't detect if the user switches venv; they will have to reload the window such that we can correctly work with the new version. Luckily, switching venvs is not something that occurs that frequently.


---

### Reviewers

There are many different code paths, please try to test them all, by manually inserting statements. E.g. one scenario is: Manim version could not be determined at the beginning, but after "Try again" it can be determined. Or another: Manim version could not be determined, user clicks on _Preview & Reload_, warning message shows up, user clicks on "Try to determine again", then version is determined and command should work now. Etc.