### PR TITLE
Fix clipboard timing issues

### DIFF
--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -85,6 +85,17 @@ enum ManimShellEvent {
  */
 export interface CommandExecutionEventHandler {
   /**
+   * Callback that is invoked right before the command is issued. This is useful
+   * to perform any actions before the command is actually sent to the terminal.
+   * Since beforehand, a new shell might be spawned which could take some time
+   * (e.g. depending on user-defined custom delay settings).
+   *
+   * This method is awaited for, i.e. the command execution is paused until this
+   * method has finished executing.
+   */
+  beforeCommandIssued?: () => Promise<void>;
+
+  /**
    * Callback that is invoked when the command is issued, i.e. sent to the
    * terminal. At this point, the command is probably not yet finished
    * executing.
@@ -357,6 +368,7 @@ export class ManimShell {
 
     let currentExecutionCount = this.iPythonCellCount;
 
+    await handler?.beforeCommandIssued?.();
     this.exec(shell, command);
     handler?.onCommandIssued?.(this.activeShell !== null);
 

--- a/src/previewCode.ts
+++ b/src/previewCode.ts
@@ -109,10 +109,13 @@ export async function previewCode(code: string, startLine: number): Promise<void
 
   try {
     const clipboardBuffer = await vscode.env.clipboard.readText();
-    await vscode.env.clipboard.writeText(code);
-
     await ManimShell.instance.executeIPythonCommand(
       PREVIEW_COMMAND, startLine, true, {
+
+        beforeCommandIssued: async () => {
+          await vscode.env.clipboard.writeText(code);
+        },
+
         onCommandIssued: (shellStillExists) => {
           Logger.debug(`📊 Command issued: ${PREVIEW_COMMAND}. Will restore clipboard`);
           restoreClipboard(clipboardBuffer);
@@ -123,12 +126,15 @@ export async function previewCode(code: string, startLine: number): Promise<void
             Logger.debug("📊 Shell was closed in the meantime, not showing progress");
           }
         },
+
         onData: (data) => {
           progress?.reportOnData(data);
         },
+
         onReset: () => {
           progress?.finish();
         },
+
       });
   } finally {
     progress?.finish();


### PR DESCRIPTION
We were writing to the clipboard even before a new terminal might have spun up. The latter can take some time and we also respect a user-defined terminal delay. If this delay is a big value, in the meantime, the clipboard could have already gotten tampered with by the user itself or by another program etc. We minimize this risk by now writing to the clipboard immediately before sending the `checkpoint_paste()` command, thus make this command more robust. The restore logic of the clipboard is not changed.