### PR TITLE
Let users cancel Manim starting

### DIFF
--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -502,6 +502,7 @@ export class ManimShell {
   public resetActiveShell() {
     Logger.debug("💫 Reset active shell");
     this.isExecutingCommand = false;
+    this.lockDuringStartup = false;
     this.iPythonCellCount = 0;
     this.activeShell = null;
     this.shellWeTryToSpawnIn = null;


### PR DESCRIPTION
Closes #35. We let users cancel the starting of Manim (`manimgl`).
The other request in #35, namely that the terminal should be focused whenever we encounter an error, was already implemented.